### PR TITLE
Workflow Update - Fix macOS Binary

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -9,7 +9,7 @@ jobs:
   build_on_linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@master
       with:
         node-version: 21
@@ -23,7 +23,7 @@ jobs:
   build_on_mac:
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@master
       with:
         node-version: 21
@@ -46,7 +46,7 @@ jobs:
   build_on_win:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@master
       with:
         node-version: 21

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -2,7 +2,7 @@ name: BuildnPub_WLGate
 on:
   push:
     branches:
-      - mac_action
+      - master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -1,11 +1,8 @@
-# name of your github action
 name: BuildnPub_WLGate
-# this will help you specify where to run 
 on:
   push:
     branches:
-    # this will run on the electron branch
-      - master
+      - mac_action
   workflow_dispatch:
 
 jobs:
@@ -18,12 +15,10 @@ jobs:
         node-version: 21
     - name: install dependencies
       run: npm install
-    - name: build
-      run: npm run make -- --platform linux --arch=x64
-    - name: publish
+    - name: build and publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: npm run publish --from-dry-run
+      run: npx electron-forge publish --platform linux --arch=x64
 
   build_on_mac:
     runs-on: macos-14
@@ -42,12 +37,10 @@ jobs:
         npm install -g appdmg@0.6.6
     - name: install dependencies
       run: npm install
-    - name: build
-      run: npm run make --arch=universal
-    - name: publish
+    - name: build and publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: npm run publish --from-dry-run
+      run: npx electron-forge publish --arch=universal
 
 
   build_on_win:
@@ -59,9 +52,7 @@ jobs:
         node-version: 21
     - name: install dependencies
       run: npm install
-    - name: build
-      run: npm run make
-    - name: publish
+    - name: build and publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: npm run publish --from-dry-run
+      run: npx electron-forge publish

--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ Enjoy
 
 #### Contributing
 Contribution is welcome. PRs will only be accepted against the Dev-Branch.
+

--- a/forge.config.js
+++ b/forge.config.js
@@ -10,7 +10,7 @@ module.exports = {
 			name: '@electron-forge/publisher-github',
 			config: {
 				repository: {
-					owner: 'HB9HIL',
+					owner: 'wavelog',
 					name: 'WaveLogGate'
 				},
 				prerelease: false

--- a/forge.config.js
+++ b/forge.config.js
@@ -10,7 +10,7 @@ module.exports = {
 			name: '@electron-forge/publisher-github',
 			config: {
 				repository: {
-					owner: 'wavelog',
+					owner: 'HB9HIL',
 					name: 'WaveLogGate'
 				},
 				prerelease: false
@@ -25,8 +25,9 @@ module.exports = {
 		},
 		{
 			name: '@electron-forge/maker-dmg',
-			config: { format: 'ULFO' },
+			config: { format: 'UDZO' },
 			platforms: ['darwin'],
+			arch: ['universal'],
 		},
 		{
 			name: '@electron-forge/maker-deb',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "WaveLog_Gate_by_DJ7NT",
+  "name": "wavelog-gate-by-dj7nt",
   "productName": "WaveLogGate",
   "description": "Gateway for connecting WSJT-* and FLRig to Wavelog",
   "keywords": [],


### PR DESCRIPTION
There was an issue with compiling the mac binary as Universal version (should work on ARM64 and x86 Systems). I fixed this issue by adjusting the workflow. 
In addition to that I removed the dedicated build commands as the `npx electron-forge publish` command does the build anyway. This way I was able to reduce the workflow time from 4.5 Minutes so 2.5 Minutes. 

A Log of this workflow can be found [here](https://github.com/HB9HIL/WaveLogGate/actions/runs/10292431490)

The output files of this workflow as example [here](https://github.com/HB9HIL/WaveLogGate/releases/tag/v1.0.16)

<img width="1241" alt="image" src="https://github.com/user-attachments/assets/410e0164-3cab-4913-9fb7-283187bd7d1e">
