### PR TITLE
Add build for arm64

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -23,7 +23,7 @@ jobs:
     - name: build and publish arm64
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: npx electron-forge publish --platform linux --arch=armv64
+      run: npx electron-forge publish --platform linux --arch=arm64
 
   build_on_mac:
     runs-on: macos-14

--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ Enjoy
 ## Contributing
 
 Contribution is welcome. PRs will only be accepted against the Dev-Branch.
+
+## Troubleshooting
+Since we are not able to test every Linux-Version out there, we're collecting some "workarounds" and tips if there are problems with the Linux-Version.
+* Problem: libasound.so.2 cannot be found AND possible Problems for Raspberry: [Blogpost from DB4SCW (Thank u!)](https://www.db4scw.de/getting-waveloggate-to-run-on-the-raspberry-pi/)
+##


### PR DESCRIPTION
This PR adds the compilation target to produce an `arm64` architecture build, which is required for running WaveLogGate on modern Raspberry PI boards. 

Closes #30 