### PR TITLE
DRAFT: Support reading band info from parsedXML

### DIFF
--- a/main.js
+++ b/main.js
@@ -402,6 +402,7 @@ ports.forEach(port => {
 						TIME_ON: qsodat.t,
 						RST_RCVD: parsedXML.contactinfo.rcv[0],
 						RST_SENT: parsedXML.contactinfo.snt[0],
+						BAND: parsedXML.contactinfo.band[0] + 'm',
 						FREQ: ((1*parseInt(parsedXML.contactinfo.txfreq[0]))/100000).toString(),
 						FREQ_RX: ((1*parseInt(parsedXML.contactinfo.rxfreq[0]))/100000).toString(),
 						OPERATOR: parsedXML.contactinfo.operator[0],


### PR DESCRIPTION
Reading band from the XML to avoid band undefined error on N1MM produced logs.

It seems https://github.com/goodspeed34/WaveLogGate/blob/c8f326f973e4d85c3cc8eeda193b722691f03014/renderer.js#L157 introduced a regression where it broke the log syncing from N1MM because the band property was undefined.

The commit supports reading band info from XML to avoid that error. Currently untested, but I will do it in a short time.