### PR TITLE
Support determining band info from parsedXML frequency

### DIFF
--- a/main.js
+++ b/main.js
@@ -299,6 +299,18 @@ function writeADIF(adifObject) {
 	return adiWriter;
 }
 
+function freqToBand(freq_mz) {
+	const f = parseFloat(freq_mz);
+	if (isNaN(f)) return null;
+
+	const bandMap = require('tcadif/lib/enums/Band');
+	for (const [band, { lowerFreq, upperFreq }] of Object.entries(bandMap))
+		if (f >= parseFloat(lowerFreq) && f <= parseFloat(upperFreq))
+			return band;
+
+	return null;
+}
+
 function send2wavelog(o_cfg,adif, dryrun = false) {
 	let clpayload={};
 	clpayload.key=o_cfg.wavelog_key.trim();
@@ -413,6 +425,8 @@ ports.forEach(port => {
 						GRIDSQUARE: parsedXML.contactinfo.gridsquare[0],
 						STATION_CALLSIGN: parsedXML.contactinfo.mycall[0]
 					} ]};
+				let band = freqToBand(adobject.qsos[0].FREQ);
+				if (band) adobject.qsos[0].BAND = band;
 			} catch (e) {}
 		} else {
 			try {

--- a/renderer.js
+++ b/renderer.js
@@ -154,9 +154,9 @@ window.TX_API.onUpdateMsg((value) => {
 
 window.TX_API.onUpdateTX((value) => {
 	if (value.created) {
-		$("#log").html('<div class="alert alert-success" role="alert">'+value.qsos[0].TIME_ON+" "+value.qsos[0].CALL+" ("+(value.qsos[0].GRIDSQUARE || 'No Grid')+") on "+value.qsos[0].BAND+" (R:"+(value.qsos[0].RST_RCVD || 'No RST')+" / S:"+(value.qsos[0].RST_SENT || 'No RST')+') - OK</div>');
+		$("#log").html('<div class="alert alert-success" role="alert">'+value.qsos[0].TIME_ON+" "+value.qsos[0].CALL+" ("+(value.qsos[0].GRIDSQUARE || 'No Grid')+") on "+(value.qsos[0].BAND || 'No BAND')+" (R:"+(value.qsos[0].RST_RCVD || 'No RST')+" / S:"+(value.qsos[0].RST_SENT || 'No RST')+') - OK</div>');
 	} else {
-		$("#log").html('<div class="alert alert-danger" role="alert">'+value.qsos[0].TIME_ON+" "+value.qsos[0].CALL+" ("+(value.qsos[0].GRIDSQUARE || 'No Grid')+") on "+value.qsos[0].BAND+" (R:"+(value.qsos[0].RST_RCVD || 'No RST')+" / S:"+(value.qsos[0].RST_SENT || 'No RST')+') - Error<br/>Reason: '+value.fail.payload.reason+'</div>');
+		$("#log").html('<div class="alert alert-danger" role="alert">'+value.qsos[0].TIME_ON+" "+value.qsos[0].CALL+" ("+(value.qsos[0].GRIDSQUARE || 'No Grid')+") on "+(value.qsos[0].BAND || 'NO BAND')+" (R:"+(value.qsos[0].RST_RCVD || 'No RST')+" / S:"+(value.qsos[0].RST_SENT || 'No RST')+') - Error<br/>Reason: '+value.fail.payload.reason+'</div>');
 	}
 })
 


### PR DESCRIPTION
This MR was intended to resolve issues regarding https://github.com/wavelog/WaveLogGate/pull/59. From my observation, the band field in N1MM broadcasted XML is faulty and hard to parse when pushing the frequency to UHF+ bands. The MR addressed the problem by determining  band info from the frequency field instead thanks to the bandMap from `tcadif`.

Still untested yet