### PR TITLE
Fix  wrong data type in `defaultcfg.wavelog_id'

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ var q={};
 var defaultcfg = {
 	wavelog_url: "https://log.jo30.de/index.php",
 	wavelog_key: "mykey",
-	wavelog_id: 0,
+	wavelog_id: "0",
 	wavelog_radioname: 'WLGate',
 	wavelog_pmode: true,
 	flrig_host: '127.0.0.1',


### PR DESCRIPTION
 `defaultcfg.wavelog_id` should be a string as main.js L305 trims it. Because of the mistyped `wavelog_id` in `defaultcfg`, `send2wavelog` yields a "`wavelog_id.trim` is not a function" TypeError causing a vague and confusing error "Reason: undefined" on the UI.

<img width="891" height="434" alt="20250725_19h50m45s_grim" src="https://github.com/user-attachments/assets/6307116f-3e60-486e-9838-6255f36feebb" />


The two undefined combined together (as shown in the image) may be very confusing to the user tricking them to believe it's an internal bug.

After fixing the mistyped property, it shows an error with reason "missing or wrong api key" which, at least, gives the user some clues about their configurations. It's definitely not the best UX with a careless user but I believe this PR would be the first right step towards it. 


<img width="605" height="277" alt="20250725_20h37m11s_grim" src="https://github.com/user-attachments/assets/f6c2dbd2-a486-4353-bbe6-a2f591537ab5" />
