### PR TITLE
Support also Radios with "strange" CW-Modes 

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -10,7 +10,7 @@ module.exports = {
 			name: '@electron-forge/publisher-github',
 			config: {
 				repository: {
-					owner: 'int2001',
+					owner: 'wavelog',
 					name: 'WaveLogGate'
 				},
 				prerelease: false

--- a/forge.config.js
+++ b/forge.config.js
@@ -10,7 +10,7 @@ module.exports = {
 			name: '@electron-forge/publisher-github',
 			config: {
 				repository: {
-					owner: 'wavelog',
+					owner: 'int2001',
 					name: 'WaveLogGate'
 				},
 				prerelease: false

--- a/main.js
+++ b/main.js
@@ -515,7 +515,16 @@ function startserver() {
 	}
 }
 
+async function get_modes() {
+	s_mainWindow.webContents.send('get_info','rig.get_modes');
+}
 async function settrx(qrg, mode = '') {
+	let avail_modes={};
+	try {
+		avail_modes=await get_modes();
+	} catch(e) {
+		avail_modes={};
+	}
 	let to={};
 	to.qrg=qrg;
 	if (mode == 'cw') {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gateway for connecting WSJT-* and FLRig to Wavelog",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.1.9b",
+  "version": "1.1.9",
   "author": "DJ7NT",
   "scripts": {
     "start": "electron-forge start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gateway for connecting WSJT-* and FLRig to Wavelog",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.1.8",
+  "version": "1.1.9b",
   "author": "DJ7NT",
   "scripts": {
     "start": "electron-forge start",

--- a/renderer.js
+++ b/renderer.js
@@ -117,10 +117,10 @@ $(document).ready(function() {
 		resizeme(obj);
 	});
 
-	ipcRenderer.on('get_info', (event, arg) => {
-		const result = getInfo(arg);
+	ipcRenderer.on('get_info', async (event, arg) => {
+		const result = await getInfo(arg); 
 		ipcRenderer.send('get_info_result', result);
-	}
+	});
 });
 
 async function load_config() {


### PR DESCRIPTION
Before QSYing WLGate checks now the capabilities of the TRX.
e.g. icom supports CW and CW-R, while Yaesu supports only CW-L and CW-U.

Setting general to CW won't work for yaesu in that case.

this one checks and takes the next-best guess for the CW Mode.