### PR TITLE
Added Websocket

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ const {ipcMain} = require('electron')
 const http = require('http');
 const xml = require("xml2js");
 const net = require('net');
+const WebSocket = require('ws');
 
 const gotTheLock = app.requestSingleInstanceLock();
 
@@ -12,6 +13,8 @@ let s_mainWindow;
 let msgbacklog=[];
 let httpServer;
 var WServer;
+let wsServer;
+let wsClients = new Set();
 
 const DemoAdif='<call:5>DJ7NT <gridsquare:4>JO30 <mode:3>FT8 <rst_sent:3>-15 <rst_rcvd:2>33 <qso_date:8>20240110 <time_on:6>051855 <qso_date_off:8>20240110 <time_off:6>051855 <band:3>40m <freq:8>7.155783 <station_callsign:5>TE1ST <my_gridsquare:6>JO30OO <eor>';
 
@@ -140,6 +143,12 @@ ipcMain.on("setCAT", async (event,arg) => {
 ipcMain.on("quit", async (event,arg) => {
 	app.isQuitting = true;
 	app.quit();
+	event.returnValue=true;
+});
+
+ipcMain.on("radio_status_update", async (event,arg) => {
+	// Broadcast radio status updates from renderer to WebSocket clients
+	broadcastRadioStatus(arg);
 	event.returnValue=true;
 });
 
@@ -477,9 +486,84 @@ function startserver() {
 				settrx(qrg,mode);
 			}
 		}).listen(54321);
+
+		// Start WebSocket server
+		startWebSocketServer();
 	} catch(e) {
 		tomsg('Some other Tool blocks Port 2333 or 54321. Stop it, and restart this');
 	}
+}
+
+function startWebSocketServer() {
+	try {
+		wsServer = new WebSocket.Server({ port: 54322 });
+		tomsg('WebSocket server started on port 54322');
+
+		wsServer.on('connection', (ws) => {
+			wsClients.add(ws);
+			tomsg('WebSocket client connected');
+
+			ws.on('close', () => {
+				wsClients.delete(ws);
+				tomsg('WebSocket client disconnected');
+			});
+
+			ws.on('error', (error) => {
+				console.error('WebSocket error:', error);
+				wsClients.delete(ws);
+			});
+
+			// Send current radio status on connection
+			ws.send(JSON.stringify({
+				type: 'welcome',
+				message: 'Connected to WaveLogGate WebSocket server'
+			}));
+		});
+
+		wsServer.on('error', (error) => {
+			console.error('WebSocket server error:', error);
+		});
+
+	} catch(e) {
+		tomsg('Failed to start WebSocket server on port 54322: ' + e.message);
+	}
+}
+
+function broadcastFrequencyMode(frequency, mode, source = 'unknown') {
+	const message = {
+		type: 'frequency_mode_change',
+		frequency: parseInt(frequency),
+		mode: mode,
+		source: source,
+		timestamp: Date.now()
+	};
+
+	const messageStr = JSON.stringify(message);
+	wsClients.forEach((client) => {
+		if (client.readyState === WebSocket.OPEN) {
+			client.send(messageStr);
+		}
+	});
+}
+
+function broadcastRadioStatus(radioData) {
+	const message = {
+		type: 'radio_status',
+		frequency: radioData.vfo ? parseInt(radioData.vfo) : null,
+		mode: radioData.mode || null,
+		power: radioData.power || null,
+		split: radioData.split || false,
+		vfoB: radioData.vfoB ? parseInt(radioData.vfoB) : null,
+		modeB: radioData.modeB || null,
+		timestamp: Date.now()
+	};
+
+	const messageStr = JSON.stringify(message);
+	wsClients.forEach((client) => {
+		if (client.readyState === WebSocket.OPEN) {
+			client.send(messageStr);
+		}
+	});
 }
 
 
@@ -573,6 +657,9 @@ async function settrx(qrg, mode = '') {
 		client.on("error", (err) => {});
 		client.on("close", () => {});
 	}
+
+	// Broadcast frequency/mode change to WebSocket clients
+	broadcastFrequencyMode(to.qrg, to.mode, 'wavelog');
 
 	return true;
 }

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ let powerSaveBlockerId;
 let s_mainWindow;
 let msgbacklog=[];
 let httpServer;
+let currentCAT=null;
 var WServer;
 let wsServer;
 let wsClients = new Set();
@@ -518,6 +519,7 @@ function startWebSocketServer() {
 				type: 'welcome',
 				message: 'Connected to WaveLogGate WebSocket server'
 			}));
+			broadcastRadioStatus(currentCAT);
 		});
 
 		wsServer.on('error', (error) => {
@@ -530,6 +532,7 @@ function startWebSocketServer() {
 }
 
 function broadcastRadioStatus(radioData) {
+	currentCAT=radioData;
 	let message = {
 		type: 'radio_status',
 		frequency: radioData.frequency ? parseInt(radioData.frequency) : null,
@@ -538,7 +541,6 @@ function broadcastRadioStatus(radioData) {
 		radio: radioData.radio || 'wlstream',
 		timestamp: Date.now()
 	};
-
 	// Only include frequency_rx if it's not null
 	if (radioData.frequency_rx) {
 		message.frequency_rx = parseInt(radioData.frequency_rx);

--- a/main.js
+++ b/main.js
@@ -529,34 +529,20 @@ function startWebSocketServer() {
 	}
 }
 
-function broadcastFrequencyMode(frequency, mode, source = 'unknown') {
-	const message = {
-		type: 'frequency_mode_change',
-		frequency: parseInt(frequency),
-		mode: mode,
-		source: source,
-		timestamp: Date.now()
-	};
-
-	const messageStr = JSON.stringify(message);
-	wsClients.forEach((client) => {
-		if (client.readyState === WebSocket.OPEN) {
-			client.send(messageStr);
-		}
-	});
-}
-
 function broadcastRadioStatus(radioData) {
-	const message = {
+	let message = {
 		type: 'radio_status',
-		frequency: radioData.vfo ? parseInt(radioData.vfo) : null,
+		frequency: radioData.frequency ? parseInt(radioData.frequency) : null,
 		mode: radioData.mode || null,
 		power: radioData.power || null,
-		split: radioData.split || false,
-		vfoB: radioData.vfoB ? parseInt(radioData.vfoB) : null,
-		modeB: radioData.modeB || null,
+		radio: radioData.radio || 'wlstream',
 		timestamp: Date.now()
 	};
+
+	// Only include frequency_rx if it's not null
+	if (radioData.frequency_rx) {
+		message.frequency_rx = parseInt(radioData.frequency_rx);
+	}
 
 	const messageStr = JSON.stringify(message);
 	wsClients.forEach((client) => {
@@ -659,7 +645,6 @@ async function settrx(qrg, mode = '') {
 	}
 
 	// Broadcast frequency/mode change to WebSocket clients
-	broadcastFrequencyMode(to.qrg, to.mode, 'wavelog');
 
 	return true;
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jquery": "^3.7.1",
     "popper.js": "^1.16.1",
     "tcadif": "^2.3.0",
+    "ws": "^8.18.3",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {

--- a/renderer.js
+++ b/renderer.js
@@ -182,7 +182,12 @@ async function get_trx() {
 	$("#current_trx").html((currentCat.vfo/(1000*1000))+" MHz / "+currentCat.mode);
 	if (((Date.now()-lastCat) > (30*60*1000)) || (!(isDeepEqual(oldCat,currentCat)))) {
 		console.log(await informWavelog(currentCat));
+		const { ipcRenderer } = require('electron');
+		ipcRenderer.send('radio_status_update', currentCat);
 	}
+
+	// Send radio status to main process for WebSocket broadcasting
+
 	oldCat=currentCat;
 	return currentCat;
 }

--- a/renderer.js
+++ b/renderer.js
@@ -182,11 +182,7 @@ async function get_trx() {
 	$("#current_trx").html((currentCat.vfo/(1000*1000))+" MHz / "+currentCat.mode);
 	if (((Date.now()-lastCat) > (30*60*1000)) || (!(isDeepEqual(oldCat,currentCat)))) {
 		console.log(await informWavelog(currentCat));
-		const { ipcRenderer } = require('electron');
-		ipcRenderer.send('radio_status_update', currentCat);
 	}
-
-	// Send radio status to main process for WebSocket broadcasting
 
 	oldCat=currentCat;
 	return currentCat;
@@ -313,6 +309,10 @@ async function informWavelog(CAT) {
 		data.frequency=CAT.vfo;
 		data.mode=CAT.mode;
 	}
+
+	const { ipcRenderer } = require('electron');
+	console.log(data);
+	ipcRenderer.send('radio_status_update', data);
 
 	let x=await fetch(cfg.profiles[active_cfg].wavelog_url + '/api/radio', {
 		method: 'POST',


### PR DESCRIPTION
This enhances the Gate with a websocket-server.
instead of polling wavelog over and over to fetch the CAT-Data (and produce load) the idea is to use the websocket here, if the user choses this explicitly within wavelog.

Reduces load and overhead.

WavelogGate itself posts QSY / Modechanges, etc. still to wavelog. so it's more a "on Top-Feature" for low-latency and load-reduction when it comes to polling