### PR TITLE
Fix for Log4OM - K_INDEX

### DIFF
--- a/main.js
+++ b/main.js
@@ -320,11 +320,23 @@ function normalizeTxPwr(adifdata) {
 	});
 }
 
+function normalizeKIndex(adifdata) {
+	return adifdata.replace(/<K_INDEX:(\d+)>([^<]+)/gi, (match, length, value) => {
+		const numValue = parseFloat(value.trim());
+		if (isNaN(numValue)) return ''; // Remove if not a number
+		
+		// Round to nearest integer and clamp to 0-9 range
+		let kIndex = Math.round(numValue);
+		if (kIndex < 0) kIndex = 0;
+		if (kIndex > 9) kIndex = 9;
+		
+		return `<K_INDEX:${kIndex.toString().length}>${kIndex}`;
+	});
+}
+
 function manipulateAdifData(adifdata) {
 	adifdata = normalizeTxPwr(adifdata);
-
-	// Remove K_INDEX fields - fix for Log4OM
-	adifdata = adifdata.replace(/<K_INDEX:\d+>[^<]+/gi, '');
+	adifdata = normalizeKIndex(adifdata);
 	// add more manipulation if necessary here
 	// ...
 	return adifdata;


### PR DESCRIPTION
Problem:
Log4OM sends not proper format of K_INDEX field. Float is send instead of integer.

Solution:
Added proper normalizeKIndex function.

Dev notes:
This will allow easy log4OM and Wavelog integration :
<img width="451" height="319" alt="image" src="https://github.com/user-attachments/assets/cea4cf47-23b6-4ee8-aa36-4a6047801990" />

