### PR TITLE
Collector for 1.2 release

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -4,12 +4,21 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      prerelease:
+        description: 'Mark as pre-release'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_on_linux:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: set dynamic repository
+      run: |
+        node -e "let p=require('./package.json'); p.repository={type:'git',url:'https://github.com/${GITHUB_REPOSITORY}.git'}; require('fs').writeFileSync('./package.json', JSON.stringify(p, null, 2));"
     - name: install dependencies
       run: npm install
     - name: build and publish x64
@@ -25,10 +34,13 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: npx electron-forge publish --platform linux --arch=arm64
 
-  build_on_mac_arm:
+  build_on_mac:
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
+    - name: set dynamic repository
+      run: |
+        node -e "let p=require('./package.json'); p.repository={type:'git',url:'https://github.com/${GITHUB_REPOSITORY}.git'}; require('fs').writeFileSync('./package.json', JSON.stringify(p, null, 2));"
     - name: setup python
       uses: actions/setup-python@v5
       with:
@@ -39,35 +51,24 @@ jobs:
         npm install -g appdmg@0.6.6
     - name: install dependencies
       run: npm install
-    - name: build and publish
+    - name: build and publish arm64
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: npx electron-forge publish --arch=arm64
-
-  build_on_mac_x64:
-    runs-on: macos-14
-    steps:
-    - uses: actions/checkout@v4
-    - name: setup python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.12
-    - name: setup appdmg
-      run: |
-        python3 -m pip install setuptools
-        npm install -g appdmg@0.6.6
-    - name: install dependencies
-      run: npm install
-    - name: build and publish
+    - name: build and publish x64
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: npx electron-forge publish --arch=x64
-
 
   build_on_win:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
+    - name: set dynamic repository
+      shell: pwsh
+      run: |
+        $repoUrl = "https://github.com/$env:GITHUB_REPOSITORY.git"
+        node -e "let p=require('./package.json'); p.repository={type:'git',url:'$repoUrl'}; require('fs').writeFileSync('./package.json', JSON.stringify(p, null, 2));"
     - name: install dependencies
       run: npm install
     - name: build and publish

--- a/cert-install.html
+++ b/cert-install.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>SSL Certificate Installation</title>
+	<style>
+		* {
+			box-sizing: border-box;
+		}
+		body {
+			background-color: #303030;
+			color: #e0e0e0;
+			padding: 20px;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+			margin: 0;
+		}
+		.container {
+			max-width: 550px;
+			margin: 0 auto;
+		}
+		.card {
+			background-color: #404040;
+			border: 1px solid #505050;
+			border-radius: 8px;
+			overflow: hidden;
+		}
+		.card-header {
+			background-color: #505050;
+			padding: 15px 20px;
+			border-bottom: 1px solid #606060;
+		}
+		.card-header h5 {
+			margin: 0;
+			font-size: 18px;
+			font-weight: 600;
+		}
+		.card-body {
+			padding: 20px;
+		}
+		.code-block {
+			background-color: #1a1a1a;
+			padding: 12px;
+			border-radius: 4px;
+			font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
+			font-size: 12px;
+			white-space: pre-wrap;
+			word-break: break-all;
+			max-height: 120px;
+			overflow-y: auto;
+			margin-top: 8px;
+		}
+		hr {
+			border: none;
+			border-top: 1px solid #505050;
+			margin: 20px 0;
+		}
+		.btn-group {
+			display: flex;
+			gap: 10px;
+			justify-content: space-between;
+		}
+		.btn {
+			padding: 10px 20px;
+			border: none;
+			border-radius: 6px;
+			cursor: pointer;
+			font-size: 14px;
+			font-weight: 500;
+			transition: all 0.2s;
+		}
+		.btn:disabled {
+			opacity: 0.6;
+			cursor: not-allowed;
+		}
+		.btn-primary {
+			background-color: #4a90d9;
+			color: white;
+		}
+		.btn-primary:hover:not(:disabled) {
+			background-color: #357abd;
+		}
+		.btn-secondary {
+			background-color: #6c757d;
+			color: white;
+		}
+		.btn-secondary:hover {
+			background-color: #5a6268;
+		}
+		.result-box {
+			display: none;
+			margin-top: 20px;
+			padding: 15px;
+			border-radius: 6px;
+		}
+		.result-box.show {
+			display: block;
+		}
+		.result-box.success {
+			background-color: #1e4620;
+			border: 1px solid #2d6e31;
+		}
+		.result-box.warning {
+			background-color: #5a4a20;
+			border: 1px solid #8a7330;
+		}
+		.cert-icon {
+			font-size: 48px;
+			text-align: center;
+			margin-bottom: 15px;
+		}
+		.alert-info {
+			background-color: #2a3a4a;
+			border: 1px solid #3a5a7a;
+			padding: 12px 15px;
+			border-radius: 6px;
+			margin: 15px 0;
+		}
+		.alert-info strong {
+			display: block;
+			margin-bottom: 5px;
+		}
+		small {
+			display: block;
+			margin-top: 20px;
+			color: #888;
+			font-size: 12px;
+		}
+		code {
+			background-color: #1a1a1a;
+			padding: 2px 6px;
+			border-radius: 3px;
+			font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
+			font-size: 12px;
+		}
+		.spinner {
+			display: inline-block;
+			width: 14px;
+			height: 14px;
+			border: 2px solid #ffffff;
+			border-top-color: transparent;
+			border-radius: 50%;
+			animation: spin 0.6s linear infinite;
+			margin-right: 8px;
+		}
+		.spinner.d-none {
+			display: none;
+		}
+		@keyframes spin {
+			to { transform: rotate(360deg); }
+		}
+	</style>
+</head>
+<body>
+	<div class="container">
+		<div class="card">
+			<div class="card-header">
+				<h5>SSL Certificate Installation</h5>
+			</div>
+			<div class="card-body">
+				<div class="cert-icon">🔐</div>
+
+				<p>WaveLogGate has generated a self-signed SSL certificate for HTTPS support.</p>
+
+				<p><strong>Why is this needed?</strong><br>
+				When WaveLog is accessed via <code>https://</code>, browsers require a valid SSL certificate for local connections.
+				WaveLogGate generates its own certificate, but it must be installed in your system's trust store.</p>
+
+				<div class="alert-info">
+					<strong>Certificate location:</strong>
+					<div class="code-block" id="certPath">Loading...</div>
+				</div>
+
+				<hr>
+
+				<div class="btn-group">
+					<button id="closeBtn" class="btn btn-secondary" style="display: none;">Close</button>
+					<button id="skipBtn" class="btn btn-secondary">Do This Later</button>
+					<button id="installBtn" class="btn btn-primary">
+						<span class="spinner d-none" id="spinner"></span>
+						<span id="btnText">Install Certificate</span>
+					</button>
+				</div>
+
+				<div id="resultBox" class="result-box"></div>
+			</div>
+		</div>
+
+		<small>
+			<strong>Note:</strong> After installation, you may need to restart Safari for changes to take effect.
+		</small>
+	</div>
+
+	<script>
+		const { ipcRenderer } = require('electron');
+
+		document.addEventListener('DOMContentLoaded', function() {
+			const installBtn = document.getElementById('installBtn');
+			const closeBtn = document.getElementById('closeBtn');
+			const skipBtn = document.getElementById('skipBtn');
+			const certPathEl = document.getElementById('certPath');
+			const resultBox = document.getElementById('resultBox');
+			const spinner = document.getElementById('spinner');
+			const btnText = document.getElementById('btnText');
+
+			// Get certificate info
+			try {
+				const certInfo = ipcRenderer.sendSync('get_cert_info');
+				certPathEl.textContent = certInfo.certPath || 'Unknown';
+			} catch (error) {
+				certPathEl.textContent = 'Error loading certificate info';
+				console.error('Error getting cert info:', error);
+			}
+
+			// Install button click
+			installBtn.addEventListener('click', function() {
+				installBtn.disabled = true;
+				spinner.classList.remove('d-none');
+				btnText.textContent = 'Installing...';
+				resultBox.className = 'result-box';
+				resultBox.innerHTML = '';
+
+				// Perform installation
+				setTimeout(function() {
+					try {
+						const result = ipcRenderer.sendSync('install_ca_cert');
+						showResult(result);
+					} catch (error) {
+						showResult({
+							success: false,
+							message: 'Error: ' + error.message
+						});
+					}
+
+					spinner.classList.add('d-none');
+				}, 500);
+			});
+
+			// Skip button click
+			skipBtn.addEventListener('click', function() {
+				try {
+					ipcRenderer.send('close_cert_install_window');
+				} catch (error) {
+					window.close();
+				}
+			});
+
+			// Close button click
+			closeBtn.addEventListener('click', function() {
+				try {
+					ipcRenderer.send('close_cert_install_window');
+				} catch (error) {
+					window.close();
+				}
+			});
+
+			function showResult(result) {
+				resultBox.classList.add('show');
+
+				// Hide install and skip buttons, show close button
+				installBtn.style.display = 'none';
+				skipBtn.style.display = 'none';
+				closeBtn.style.display = 'inline-block';
+
+				if (result.success) {
+					resultBox.classList.add('success');
+					resultBox.innerHTML =
+						'<strong>✓ Success!</strong><br><br>' +
+						'Certificate installed successfully! Safari and other browsers should now trust the WaveLogGate HTTPS connection.<br><br>' +
+						'<em>Please restart Safari for the changes to take effect.</em>';
+				} else {
+					resultBox.classList.add('warning');
+					const message = (result.message || 'Unknown error').replace(/\n/g, '<br>');
+					resultBox.innerHTML =
+						'<strong>⚠ Automatic Installation Failed</strong><br><br>' +
+						message + '<br><br>' +
+						'<em>You can close this window and install manually later if needed.</em>';
+				}
+			}
+		});
+	</script>
+</body>
+</html>

--- a/cert-install.html
+++ b/cert-install.html
@@ -180,6 +180,7 @@
 						<span class="spinner d-none" id="spinner"></span>
 						<span id="btnText">Install Certificate</span>
 					</button>
+					<button id="copyBtn" class="btn btn-primary" style="display: none;">Copy Command</button>
 				</div>
 
 				<div id="resultBox" class="result-box"></div>
@@ -198,10 +199,12 @@
 			const installBtn = document.getElementById('installBtn');
 			const closeBtn = document.getElementById('closeBtn');
 			const skipBtn = document.getElementById('skipBtn');
+			const copyBtn = document.getElementById('copyBtn');
 			const certPathEl = document.getElementById('certPath');
 			const resultBox = document.getElementById('resultBox');
 			const spinner = document.getElementById('spinner');
 			const btnText = document.getElementById('btnText');
+			let manualCommand = '';
 
 			// Get certificate info
 			try {
@@ -266,17 +269,50 @@
 					resultBox.classList.add('success');
 					resultBox.innerHTML =
 						'<strong>✓ Success!</strong><br><br>' +
-						'Certificate installed successfully! Safari and other browsers should now trust the WaveLogGate HTTPS connection.<br><br>' +
-						'<em>Please restart Safari for the changes to take effect.</em>';
+						'Certificate installed successfully! Chrome and Safari should now trust the WaveLogGate HTTPS connection.<br><br>' +
+						'<em>Please restart your browser for the changes to take effect.</em>';
+					copyBtn.style.display = 'none';
 				} else {
 					resultBox.classList.add('warning');
-					const message = (result.message || 'Unknown error').replace(/\n/g, '<br>');
-					resultBox.innerHTML =
-						'<strong>⚠ Automatic Installation Failed</strong><br><br>' +
-						message + '<br><br>' +
-						'<em>You can close this window and install manually later if needed.</em>';
+					manualCommand = result.command || '';
+
+					let html = '<strong>⚠ Automatic Installation Failed</strong><br><br>';
+
+					if (manualCommand) {
+						html += result.message.replace(/\n/g, '<br>') + '<br><br>';
+						html += '<div class="code-block" style="max-height: 150px;">' + escapeHtml(manualCommand) + '</div><br>';
+						copyBtn.style.display = 'inline-block';
+					} else {
+						html += (result.message || 'Unknown error').replace(/\n/g, '<br>') + '<br><br>';
+						copyBtn.style.display = 'none';
+					}
+
+					html += '<em>You can close this window and install manually later if needed.</em>';
+					resultBox.innerHTML = html;
 				}
 			}
+
+			// Escape HTML to prevent XSS
+			function escapeHtml(text) {
+				const div = document.createElement('div');
+				div.textContent = text;
+				return div.innerHTML;
+			}
+
+			// Copy button click handler
+			copyBtn.addEventListener('click', function() {
+				if (manualCommand) {
+					navigator.clipboard.writeText(manualCommand).then(function() {
+						const originalText = copyBtn.textContent;
+						copyBtn.textContent = 'Copied!';
+						setTimeout(function() {
+							copyBtn.textContent = originalText;
+						}, 2000);
+					}).catch(function(err) {
+						console.error('Failed to copy:', err);
+					});
+				}
+			});
 		});
 	</script>
 </body>

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,17 +1,52 @@
+const { execSync } = require('child_process');
+
+// Get repository info dynamically from git remote
+function getRepoInfo() {
+	// In GitHub Actions, use the GITHUB_REPOSITORY environment variable
+	if (process.env.GITHUB_REPOSITORY) {
+		const [owner, name] = process.env.GITHUB_REPOSITORY.split('/');
+		return { owner, name };
+	}
+
+	// Fallback: read from git remote
+	try {
+		const remoteUrl = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+		// Handle various git URL formats:
+		// https://github.com/owner/repo.git
+		// git@github.com:owner/repo.git
+		const match = remoteUrl.match(/(?:github\.com[/:]|github\.com\/)([^/]+)\/([^/]+?)(?:\.git)?$/i);
+		if (match) {
+			return { owner: match[1], name: match[2] };
+		}
+	} catch (e) {
+		console.log('Could not determine repository from git remote:', e.message);
+	}
+
+	// Final fallback to defaults
+	return { owner: 'wavelog', name: 'WaveLogGate' };
+}
+
+const repoInfo = getRepoInfo();
+
 module.exports = {
 	packagerConfig: {
 		// set config executableName
 		executableName: "wlgate",
 		icon: './icon',
 		asar: true,
+		// Windows updater configuration
+		productName: "WaveLogGate",
+		win32Metadata: {
+			companyName: "DJ7NT"
+		}
 	},
 	publishers: [
 		{
 			name: '@electron-forge/publisher-github',
 			config: {
 				repository: {
-					owner: 'wavelog',
-					name: 'WaveLogGate'
+					owner: repoInfo.owner,
+					name: repoInfo.name
 				},
 				prerelease: false
 			}
@@ -28,6 +63,10 @@ module.exports = {
 			config: { format: 'UDZO' },
 			platforms: ['darwin'],
 			arch: ['x64','arm64'],
+		},
+		{
+			name: '@electron-forge/maker-zip',
+			platforms: ['darwin'],
 		},
 		{
 			name: '@electron-forge/maker-deb',

--- a/index.html
+++ b/index.html
@@ -121,6 +121,53 @@
 	label svg {
 		cursor: pointer;
 	}
+
+	/* Profile Manager Modal Styles */
+	#profileList {
+		max-height: 300px;
+		overflow-y: auto;
+	}
+
+	.profile-name {
+		font-weight: 500;
+	}
+
+	.list-group-item {
+		border-radius: 0 !important;
+		background-color: #303030;
+		border-color: #727272;
+		color: #c6c6c6;
+	}
+
+	.list-group-item:first-child {
+		border-top-left-radius: 0.25rem !important;
+		border-top-right-radius: 0.25rem !important;
+	}
+
+	.list-group-item:last-child {
+		border-bottom-left-radius: 0.25rem !important;
+		border-bottom-right-radius: 0.25rem !important;
+	}
+
+	.modal-content {
+		background-color: #303030;
+		color: #c6c6c6;
+		border: 1px solid #727272;
+	}
+
+	.modal-header {
+		background-color: #1c1c1c;
+		border-bottom: 1px solid #727272;
+	}
+
+	.modal-footer {
+		background-color: #1c1c1c;
+		border-top: 1px solid #727272;
+	}
+
+	.modal-body {
+		background-color: #303030;
+	}
 </style>
 
 <body>
@@ -243,7 +290,9 @@
 						</div>
 						<div class="col">
 							<div class="mb-4 col-mb-4" style="text-align: left">
-								<button type="button" class="btn btn-primary" id="toggle" title="change config-profile">1</button>
+								<button type="button" class="btn btn-primary" id="toggle" title="Manage profiles">
+									<span id="currentProfileName">Profile 1</span>
+								</button>
 							</div>
 						</div>
 						<div class="col">
@@ -263,6 +312,43 @@
 		</div>
 		<div class="card-footer">
 			<small class="mt-0.5 bottom-right" id="utc"></small>
+		</div>
+	</div>
+
+	<!-- Profile Manager Modal -->
+	<div class="modal fade" id="profileModal" tabindex="-1">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h5 class="modal-title">Profile Manager</h5>
+					<button type="button" class="close" data-dismiss="modal">
+						<span>&times;</span>
+					</button>
+				</div>
+				<div class="modal-body">
+					<!-- Profile List -->
+					<div id="profileList" class="list-group mb-3"></div>
+
+					<!-- Create New Profile -->
+					<div class="input-group">
+						<input type="text" id="newProfileName" class="form-control"
+							   placeholder="New profile name...">
+						<div class="input-group-append">
+							<button class="btn btn-success" id="btnCreateProfile">
+								Create Profile
+							</button>
+						</div>
+					</div>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-secondary" data-dismiss="modal">
+						Cancel
+					</button>
+					<button type="button" class="btn btn-primary" id="btnSelectProfile">
+						Switch to Selected
+					</button>
+				</div>
+			</div>
 		</div>
 	</div>
 

--- a/main.js
+++ b/main.js
@@ -2,9 +2,13 @@ const {app, BrowserWindow, globalShortcut, Notification, powerSaveBlocker } = re
 const path = require('node:path');
 const {ipcMain} = require('electron')
 const http = require('http');
+const https = require('https');
 const xml = require("xml2js");
 const net = require('net');
 const WebSocket = require('ws');
+const fs = require('fs');
+const selfsigned = require('selfsigned');
+const httpolyglot = require('httpolyglot');
 
 // In some cases we need to make the WLgate window resizable (for example for tiling window managers)
 // Default: false
@@ -16,7 +20,7 @@ const gotTheLock = app.requestSingleInstanceLock();
 let powerSaveBlockerId;
 let s_mainWindow;
 let msgbacklog=[];
-let httpServer;
+let qsyServer; // Dual-mode HTTP/HTTPS server for QSY
 let currentCAT=null;
 var WServer;
 let wsServer;
@@ -24,6 +28,12 @@ let wsClients = new Set();
 let isShuttingDown = false;
 let activeConnections = new Set(); // Track active TCP connections
 let activeHttpRequests = new Set(); // Track active HTTP requests for cancellation
+
+// Certificate paths for HTTPS server
+let certPaths = {
+	key: null,
+	cert: null
+};
 
 const DemoAdif='<call:5>DJ7NT <gridsquare:4>JO30 <mode:3>FT8 <rst_sent:3>-15 <rst_rcvd:2>33 <qso_date:8>20240110 <time_on:6>051855 <qso_date_off:8>20240110 <time_off:6>051855 <band:3>40m <freq:8>7.155783 <station_callsign:5>TE1ST <my_gridsquare:6>JO30OO <eor>';
 
@@ -132,6 +142,12 @@ ipcMain.on("radio_status_update", async (event,arg) => {
 	event.returnValue=true;
 });
 
+ipcMain.on("get_ca_cert", async (event) => {
+	// Return the CA certificate for display/installation
+	const caCert = getCaCertificate();
+	event.returnValue = caCert;
+});
+
 function cleanupConnections() {
     console.log('Cleaning up active TCP connections...');
 
@@ -190,9 +206,9 @@ function shutdownApplication() {
             console.log('Closing UDP server...');
             WServer.close();
         }
-        if (httpServer) {
-            console.log('Closing HTTP server...');
-            httpServer.close();
+        if (qsyServer) {
+            console.log('Closing QSY server...');
+            qsyServer.close();
         }
         if (wsServer) {
             console.log('Closing WebSocket server and clients...');
@@ -260,7 +276,7 @@ process.on('SIGINT', () => {
 
 app.on('will-quit', () => {
 	try {
-		if (!sleepable) {
+		if (!sleepable && powerSaveBlockerId !== undefined) {
 			powerSaveBlocker.stop(powerSaveBlockerId);
 		}
 	} catch(e) {
@@ -556,20 +572,147 @@ function tomsg(msg) {
 	}
 }
 
+// Generate or load self-signed certificate for HTTPS server
+function setupCertificates() {
+	const userDataPath = app.getPath('userData');
+	const certDir = path.join(userDataPath, 'certs');
+
+	// Check if certificates already exist
+	const keyPath = path.join(certDir, 'server.key');
+	const certPath = path.join(certDir, 'server.crt');
+
+	if (fs.existsSync(keyPath) && fs.existsSync(certPath)) {
+		// Load existing certificates
+		certPaths = {
+			key: fs.readFileSync(keyPath),
+			cert: fs.readFileSync(certPath)
+		};
+		console.log('Using existing SSL certificates');
+		return true;
+	}
+
+	// Generate new certificates
+	try {
+		// Create cert directory if it doesn't exist
+		if (!fs.existsSync(certDir)) {
+			fs.mkdirSync(certDir, { recursive: true });
+		}
+
+		// Generate self-signed certificate
+		const attrs = [{ name: 'commonName', value: 'WaveLogGate' }];
+		const certs = selfsigned.generate(attrs, {
+			days: 3650, // 10 years
+			altNames: [
+				{ type: 2, value: 'localhost' },
+				{ type: 2, value: '127.0.0.1' },
+				{ type: 2, value: '::1' },
+				{ type: 7, ip: '127.0.0.1' },
+				{ type: 7, ip: '::1' }
+			]
+		});
+
+		// Save certificates
+		fs.writeFileSync(keyPath, certs.private);
+		fs.writeFileSync(certPath, certs.cert);
+
+		certPaths = {
+			key: certs.private,
+			cert: certs.cert
+		};
+
+		console.log('Generated new SSL certificates');
+		return true;
+	} catch (error) {
+		console.error('Failed to generate certificates:', error);
+		tomsg('Warning: Failed to generate SSL certificates. HTTPS server will not be available.');
+		return false;
+	}
+}
+
+// Get certificate for user installation
+function getCaCertificate() {
+	const userDataPath = app.getPath('userData');
+	const certPath = path.join(userDataPath, 'certs', 'server.crt');
+
+	if (fs.existsSync(certPath)) {
+		return fs.readFileSync(certPath, 'utf8');
+	}
+	return null;
+}
+
+// Request handler for both HTTP and HTTPS servers
+function createRequestHandler(req, res) {
+	// Handle CORS preflight requests (OPTIONS)
+	if (req.method === 'OPTIONS') {
+		res.setHeader('Access-Control-Allow-Origin', '*');
+		res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+		res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
+		res.setHeader('Access-Control-Max-Age', '86400');
+		res.writeHead(204);
+		res.end();
+		return;
+	}
+
+	// Handle QSY requests
+	res.setHeader('Access-Control-Allow-Origin', '*');
+	res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+	res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
+
+	const parts = req.url.substr(1).split('/');
+	const qrg = parts[0];
+	const mode = parts[1] || '';
+
+	if (Number.isInteger(Number.parseInt(qrg))) {
+		settrx(qrg,mode);
+		res.writeHead(200, {'Content-Type': 'text/plain'});
+		res.end('OK');
+	} else {
+		res.writeHead(400, {'Content-Type': 'text/plain'});
+		res.end('Invalid frequency');
+	}
+}
+
 function startserver() {
 	try {
+		// Setup SSL certificates
+		const hasCerts = setupCertificates();
+
 		tomsg('Waiting for QSO / Listening on UDP 2333');
-		httpServer = http.createServer(function (req, res) {
-			res.setHeader('Access-Control-Allow-Origin', '*');
-			res.writeHead(200, {'Content-Type': 'text/plain'});
-			res.end('');
-			const parts = req.url.substr(1).split('/');
-			const qrg = parts[0];
-			const mode = parts[1] || '';
-			if (Number.isInteger(Number.parseInt(qrg))) {
-				settrx(qrg,mode);
-			}
-		}).listen(54321);
+
+		// Create dual-mode HTTP/HTTPS server on port 54321
+		if (hasCerts && certPaths.key && certPaths.cert) {
+			// Create httpolyglot server (handles both HTTP and HTTPS on same port)
+			const serverOptions = {
+				key: certPaths.key,
+				cert: certPaths.cert,
+				minVersion: 'TLSv1.2'
+			};
+
+			qsyServer = httpolyglot.createServer(serverOptions, createRequestHandler);
+			qsyServer.on('error', (err) => {
+				if (err.code === 'EADDRINUSE') {
+					console.error('QSY server port 54321 already in use');
+				} else {
+					console.error('QSY server error:', err);
+				}
+			});
+			qsyServer.listen(54321, () => {
+				console.log('Dual-mode HTTP/HTTPS QSY server listening on port 54321');
+			});
+		} else {
+			// Fallback to HTTP-only if certificates are not available
+			qsyServer = http.createServer(createRequestHandler);
+			qsyServer.on('error', (err) => {
+				if (err.code === 'EADDRINUSE') {
+					console.error('QSY server port 54321 already in use');
+				} else {
+					console.error('QSY server error:', err);
+				}
+			});
+			qsyServer.listen(54321, () => {
+				console.log('HTTP-only QSY server listening on port 54321');
+			});
+		}
 
 		// Start WebSocket server
 		startWebSocketServer();

--- a/main.js
+++ b/main.js
@@ -119,6 +119,16 @@ ipcMain.on("get_config", async (event, arg) => {
 	} else {
 		realcfg=storedcfg;
 	}
+	// Migration: Add version and profileNames for dynamic profile system
+	if (!realcfg.version || realcfg.version < 2) {
+		realcfg.version = 2;
+		if (!realcfg.profileNames) {
+			realcfg.profileNames = realcfg.profiles.map((_, i) => `Profile ${i + 1}`);
+		}
+		storage.set('basic', realcfg, function(e) {
+			if (e) throw e;
+		});
+	}
 	if ((arg ?? '') !== '') {
 		realcfg.profile=arg;
 	}
@@ -175,6 +185,80 @@ ipcMain.on("close_cert_install_window", async () => {
 	if (certInstallWindow && !certInstallWindow.isDestroyed()) {
 		certInstallWindow.close();
 	}
+});
+
+// Dynamic Profile System IPC Handlers
+
+ipcMain.on("create_profile", async (event, name) => {
+	let data = storage.getSync('basic');
+
+	const newProfile = {
+		wavelog_url: data.profiles[data.profile || 0].wavelog_url || '',
+		wavelog_key: data.profiles[data.profile || 0].wavelog_key || '',
+		wavelog_id: data.profiles[data.profile || 0].wavelog_id || '0',
+		wavelog_radioname: 'WLGate',
+		wavelog_pmode: true,
+		flrig_host: '127.0.0.1',
+		flrig_port: '12345',
+		flrig_ena: false,
+		hamlib_host: '127.0.0.1',
+		hamlib_port: '4532',
+		hamlib_ena: false,
+		ignore_pwr: false
+	};
+
+	data.profiles.push(newProfile);
+	data.profileNames.push(name || `Profile ${data.profiles.length}`);
+
+	storage.setSync('basic', data);
+
+	event.returnValue = { success: true, index: data.profiles.length - 1 };
+});
+
+ipcMain.on("delete_profile", async (event, index) => {
+	let data = storage.getSync('basic');
+
+	// Prevent deleting if only 2 profiles remain
+	if (data.profiles.length <= 2) {
+		event.returnValue = { success: false, error: 'Minimum 2 profiles required' };
+		return;
+	}
+
+	// Prevent deleting active profile
+	if ((data.profile || 0) === index) {
+		event.returnValue = { success: false, error: 'Cannot delete active profile' };
+		return;
+	}
+
+	data.profiles.splice(index, 1);
+	data.profileNames.splice(index, 1);
+
+	// Adjust active index if needed
+	if ((data.profile || 0) > index) {
+		data.profile = (data.profile || 0) - 1;
+	}
+
+	storage.setSync('basic', data);
+
+	event.returnValue = { success: true };
+});
+
+ipcMain.on("rename_profile", async (event, index, newName) => {
+	let data = storage.getSync('basic');
+	data.profileNames[index] = newName;
+
+	storage.setSync('basic', data);
+
+	event.returnValue = { success: true };
+});
+
+ipcMain.on("switch_profile", async (event, index) => {
+	let data = storage.getSync('basic');
+	data.profile = index;
+
+	storage.setSync('basic', data);
+
+	event.returnValue = { success: true };
 });
 
 function cleanupConnections() {

--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@ const xml = require("xml2js");
 const net = require('net');
 const WebSocket = require('ws');
 const fs = require('fs');
-const selfsigned = require('selfsigned');
+const forge = require('node-forge');
 const httpolyglot = require('httpolyglot');
 
 // In some cases we need to make the WLgate window resizable (for example for tiling window managers)
@@ -616,26 +616,68 @@ function setupCertificates() {
 			fs.mkdirSync(certDir, { recursive: true });
 		}
 
-		// Generate self-signed certificate
-		const attrs = [{ name: 'commonName', value: '127.0.0.1' }];
-		const certs = selfsigned.generate(attrs, {
-			days: 3650, // 10 years
-			altNames: [
-				{ type: 2, value: 'localhost' },
-				{ type: 2, value: '127.0.0.1' },
-				{ type: 2, value: '::1' },
-				{ type: 7, ip: '127.0.0.1' },
-				{ type: 7, ip: '::1' }
-			]
-		});
+		// Generate RSA key pair
+		const keys = forge.pki.rsa.generateKeyPair(2048);
+
+		// Create certificate
+		const cert = forge.pki.createCertificate();
+		cert.publicKey = keys.publicKey;
+		cert.serialNumber = '01';
+		cert.validity.notBefore = new Date();
+		cert.validity.notAfter = new Date();
+		cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 10); // 10 years
+
+		// Set subject and issuer (self-signed)
+		const attrs = [{
+			name: 'commonName',
+			value: '127.0.0.1'
+		}];
+		cert.setSubject(attrs);
+		cert.setIssuer(attrs);
+
+		// Add extensions including SANs
+		cert.setExtensions([{
+			name: 'basicConstraints',
+			cA: true
+		}, {
+			name: 'keyUsage',
+			keyCertSign: true,
+			digitalSignature: true,
+			nonRepudiation: true,
+			keyEncipherment: true,
+			dataEncipherment: true
+		}, {
+			name: 'extKeyUsage',
+			serverAuth: true,
+			clientAuth: true
+		}, {
+			name: 'subjectAltName',
+			altNames: [{
+				type: 7, // IP address
+				ip: '127.0.0.1'
+			}, {
+				type: 2, // DNS name
+				value: 'localhost'
+			}, {
+				type: 7, // IPv6 address
+				ip: '::1'
+			}]
+		}]);
+
+		// Self-sign the certificate
+		cert.sign(keys.privateKey);
+
+		// Convert to PEM format
+		const certPem = forge.pki.certificateToPem(cert);
+		const keyPem = forge.pki.privateKeyToPem(keys.privateKey);
 
 		// Save certificates
-		fs.writeFileSync(keyPath, certs.private);
-		fs.writeFileSync(certPath, certs.cert);
+		fs.writeFileSync(keyPath, keyPem);
+		fs.writeFileSync(certPath, certPem);
 
 		certPaths = {
-			key: certs.private,
-			cert: certs.cert
+			key: keyPem,
+			cert: certPem
 		};
 
 		console.log('Generated new SSL certificates');

--- a/main.js
+++ b/main.js
@@ -20,6 +20,7 @@ const gotTheLock = app.requestSingleInstanceLock();
 let powerSaveBlockerId;
 let s_mainWindow;
 let certInstallWindow;
+let pendingCertInstall = false; // Track if cert install needs to be shown
 let msgbacklog=[];
 let qsyServer; // Dual-mode HTTP/HTTPS server for QSY
 let currentCAT=null;
@@ -343,6 +344,14 @@ if (!gotTheLock) {
 				s_mainWindow.webContents.send('updateMsg',msgbacklog.pop());
 			}
 		});
+
+		// Show certificate install window if it was pending (before main window was ready)
+		if (pendingCertInstall) {
+			// Small delay to ensure main window is fully visible
+			setTimeout(() => {
+				showCertInstallWindow();
+			}, 500);
+		}
 	});
 }
 
@@ -913,12 +922,24 @@ function showCertInstallWindow() {
 		return;
 	}
 
+	// If main window is not ready yet, mark as pending and return
+	// The main window ready handler will call this again
+	if (!s_mainWindow || s_mainWindow.isDestroyed()) {
+		pendingCertInstall = true;
+		console.log('Main window not ready, cert install will show after window is ready');
+		return;
+	}
+
+	pendingCertInstall = false;
+
+	// Determine if we should attach to parent (only if main window is visible and ready)
+	const useParent = s_mainWindow && !s_mainWindow.isDestroyed() && s_mainWindow.isVisible();
+
 	certInstallWindow = new BrowserWindow({
 		width: 600,
 		height: 500,
 		resizable: false,
-		parent: s_mainWindow,
-		modal: true,
+		...(useParent ? { parent: s_mainWindow, modal: true } : {}),
 		autoHideMenuBar: app.isPackaged,
 		webPreferences: {
 			contextIsolation: false,

--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ const gotTheLock = app.requestSingleInstanceLock();
 
 let powerSaveBlockerId;
 let s_mainWindow;
+let certInstallWindow;
 let msgbacklog=[];
 let qsyServer; // Dual-mode HTTP/HTTPS server for QSY
 let currentCAT=null;
@@ -164,6 +165,12 @@ ipcMain.on("get_cert_info", async (event) => {
 		platform: process.platform,
 		hasCert: fs.existsSync(certPath)
 	};
+});
+
+ipcMain.on("close_cert_install_window", async () => {
+	if (certInstallWindow && !certInstallWindow.isDestroyed()) {
+		certInstallWindow.close();
+	}
 });
 
 function cleanupConnections() {
@@ -829,6 +836,41 @@ function createRequestHandler(req, res) {
 	}
 }
 
+function showCertInstallWindow() {
+	// Close existing window if open
+	if (certInstallWindow && !certInstallWindow.isDestroyed()) {
+		certInstallWindow.focus();
+		return;
+	}
+
+	certInstallWindow = new BrowserWindow({
+		width: 600,
+		height: 500,
+		resizable: false,
+		parent: s_mainWindow,
+		modal: true,
+		autoHideMenuBar: app.isPackaged,
+		webPreferences: {
+			contextIsolation: false,
+			nodeIntegration: true,
+			devTools: !app.isPackaged,
+			enableRemoteModule: true,
+			preload: path.join(__dirname, 'preload.js')
+		}
+	});
+
+	if (app.isPackaged) {
+		certInstallWindow.setMenu(null);
+	}
+
+	certInstallWindow.loadFile('cert-install.html');
+	certInstallWindow.setTitle('WaveLogGate - SSL Certificate Installation');
+
+	certInstallWindow.on('closed', () => {
+		certInstallWindow = null;
+	});
+}
+
 function startserver() {
 	try {
 		// Setup SSL certificates
@@ -840,9 +882,7 @@ function startserver() {
 		if (certResult.success && certResult.newlyGenerated) {
 			// Schedule prompt after window is ready
 			setTimeout(() => {
-				if (s_mainWindow && !s_mainWindow.isDestroyed()) {
-					s_mainWindow.webContents.send('prompt_cert_install');
-				}
+				showCertInstallWindow();
 			}, 2000);
 		}
 

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const {app, BrowserWindow, globalShortcut, Notification, powerSaveBlocker } = require('electron/main');
+const {app, BrowserWindow, globalShortcut, Notification, powerSaveBlocker, dialog, shell } = require('electron/main');
 const path = require('node:path');
 const {ipcMain} = require('electron')
 const http = require('http');
@@ -64,6 +64,131 @@ let defaultcfg = {
 
 const storage = require('electron-json-storage');
 
+// =============================================================================
+// Simple Update Checker
+// =============================================================================
+
+// Get repository info from package.json
+function getRepoInfo() {
+	try {
+		const pkg = require('./package.json');
+		if (pkg.repository && pkg.repository.url) {
+			const match = pkg.repository.url.match(/github\.com[/:]([^/]+)\/([^/]+)/);
+			if (match) {
+				return { owner: match[1], repo: match[2].replace('.git', '') };
+			}
+		}
+	} catch (e) {
+		console.log('Could not read repository info:', e.message);
+	}
+	// Fallback to defaults
+	return { owner: 'wavelog', repo: 'WaveLogGate' };
+}
+
+// Compare two version strings (returns true if v2 > v1)
+function isNewerVersion(v1, v2) {
+	const parts1 = v1.split('.').map(Number);
+	const parts2 = v2.split('.').map(Number);
+	for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+		const p1 = parts1[i] || 0;
+		const p2 = parts2[i] || 0;
+		if (p2 > p1) return true;
+		if (p2 < p1) return false;
+	}
+	return false;
+}
+
+// Check for updates via GitHub API
+function checkForUpdates() {
+	if (!app.isPackaged) {
+		console.log('Skipping update check (development mode)');
+		return;
+	}
+
+	const repoInfo = getRepoInfo();
+	const currentVersion = app.getVersion();
+
+	console.log(`Checking for updates (current: ${currentVersion})...`);
+
+	const options = {
+		hostname: 'api.github.com',
+		path: `/repos/${repoInfo.owner}/${repoInfo.repo}/releases/latest`,
+		headers: {
+			'User-Agent': 'WaveLogGate'
+		}
+	};
+
+	https.get(options, (res) => {
+		let data = '';
+
+		res.on('data', (chunk) => {
+			data += chunk;
+		});
+
+		res.on('end', () => {
+			try {
+				const release = JSON.parse(data);
+				const latestVersion = release.tag_name.replace(/^v/, '');
+
+				console.log(`Latest version: ${latestVersion}`);
+
+				if (isNewerVersion(currentVersion, latestVersion)) {
+					console.log(`Update available: ${latestVersion}`);
+					showUpdateNotification(latestVersion, release.html_url);
+				} else {
+					console.log('Already up to date');
+				}
+			} catch (e) {
+				console.error('Error parsing release info:', e.message);
+			}
+		});
+	}).on('error', (err) => {
+		console.error('Error checking for updates:', err.message);
+	});
+}
+
+// Show notification about available update
+function showUpdateNotification(version, releaseUrl) {
+	// On Windows, use dialog because notification clicks don't work reliably
+	if (process.platform === 'win32') {
+		dialog.showMessageBox({
+			type: 'info',
+			title: 'WaveLogGate Update Available',
+			message: `A new version is available!`,
+			detail: `Version ${version} is ready to download. You are currently running v${app.getVersion()}.`,
+			buttons: ['Go to Download', 'Later'],
+			defaultId: 0,
+			cancelId: 1
+		}).then(result => {
+			if (result.response === 0) {
+				console.log('Opening download page:', releaseUrl);
+				shell.openExternal(releaseUrl);
+			}
+		});
+		return;
+	}
+
+	// On macOS/Linux, use native notification (click works on macOS)
+	if (Notification.isSupported()) {
+		const notification = new Notification({
+			title: 'WaveLogGate Update Available',
+			body: `Version ${version} is available. Click to download.`,
+			icon: path.join(__dirname, 'icon.png'),
+			silent: false
+		});
+
+		notification.once('click', () => {
+			console.log('Notification clicked, opening:', releaseUrl);
+			shell.openExternal(releaseUrl);
+		});
+
+		notification.show();
+	} else {
+		// Fallback: log to console
+		console.log(`Update available: ${version} - Download from: ${releaseUrl}`);
+	}
+}
+
 app.disableHardwareAcceleration(); 
 
 function createWindow () {
@@ -76,7 +201,7 @@ function createWindow () {
 			contextIsolation: false,
 			backgroundThrottling: false,
 			nodeIntegration: true,
-			devTools: !app.isPackaged,
+			devTools: true, // Enable for debugging auto-updater
 			enableRemoteModule: true,
 			preload: path.join(__dirname, 'preload.js')
 		}
@@ -175,6 +300,12 @@ ipcMain.on("close_cert_install_window", async () => {
 	if (certInstallWindow && !certInstallWindow.isDestroyed()) {
 		certInstallWindow.close();
 	}
+});
+
+ipcMain.on("check_for_updates", async (event) => {
+	// Manual update check triggered from renderer
+	checkForUpdates();
+	event.returnValue = true;
 });
 
 function cleanupConnections() {
@@ -343,6 +474,8 @@ if (!gotTheLock) {
 			if (msgbacklog.length>0) {
 				s_mainWindow.webContents.send('updateMsg',msgbacklog.pop());
 			}
+			// Check for updates on startup
+			checkForUpdates();
 		});
 
 		// Show certificate install window if it was pending (before main window was ready)

--- a/main.js
+++ b/main.js
@@ -645,14 +645,11 @@ function setupCertificates() {
 		// Add extensions including SANs
 		cert.setExtensions([{
 			name: 'basicConstraints',
-			cA: true
+			cA: false
 		}, {
 			name: 'keyUsage',
-			keyCertSign: true,
 			digitalSignature: true,
-			nonRepudiation: true,
-			keyEncipherment: true,
-			dataEncipherment: true
+			keyEncipherment: true
 		}, {
 			name: 'extKeyUsage',
 			serverAuth: true,
@@ -725,30 +722,37 @@ async function installCertificate() {
 
 	try {
 		if (platform === 'darwin') {
-			// macOS - try to install in user keychain (no sudo required)
-			// Then provide instruction for system keychain
+			// macOS - Use AppleScript to run with admin privileges (shows native password dialog)
 			try {
-				// Try user keychain first (no sudo needed)
-				execSync(`security add-trusted-cert -d -r trustRoot -k ~/Library/Keychains/login.keychain-db "${certPath}"`, { stdio: 'ignore' });
-				console.log('Certificate installed in user keychain');
+				// Escape the certificate path for shell and AppleScript
+				const escapedCertPath = certPath.replace(/'/g, "'\\''");
+
+				// Use AppleScript to execute with administrator privileges
+				// This shows the native macOS authentication dialog
+				const appleScript = `
+					do shell script "security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain '${escapedCertPath}'" with administrator privileges
+				`;
+
+				execSync(`osascript -e '${appleScript.replace(/'/g, "'\\''")}'`, { stdio: 'ignore' });
+				console.log('Certificate installed in System keychain via AppleScript');
 				return {
 					success: true,
-					message: 'Certificate installed in user keychain. Safari should now trust it.',
+					message: 'Certificate installed in System keychain. Chrome and Safari should now trust it after restart.',
 					manual: false
 				};
-			} catch (userError) {
-				// Fallback instructions for system keychain
-				console.log('Could not install in user keychain, providing manual instructions');
+			} catch (sysError) {
+				console.log('AppleScript installation failed:', sysError.message);
 				return {
 					success: false,
-					message: `Automatic installation failed. Please run this command in Terminal:\n\nsudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "${certPath}"`,
+					message: `Installation was cancelled or failed.\n\nPlease try again and enter your macOS password when prompted.\n\nIf you prefer manual installation, run this command in Terminal:\n\nsudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain "${certPath}"`,
 					manual: true,
-					command: `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "${certPath}"`
+					command: `sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain "${certPath}"`
 				};
 			}
 		} else if (platform === 'win32') {
-			// Windows - use certutil (may require admin)
+			// Windows - try to install with elevation prompt
 			try {
+				// Try direct install first (if already running as admin)
 				execSync(`certutil -addstore -f Root "${certPath}"`, { stdio: 'ignore' });
 				console.log('Certificate installed in Windows trust store');
 				return {
@@ -757,22 +761,62 @@ async function installCertificate() {
 					manual: false
 				};
 			} catch (winError) {
-				return {
-					success: false,
-					message: `Installation requires Administrator privileges. Please run PowerShell as Administrator and execute:\n\ncertutil -addstore -f Root "${certPath}"`,
-					manual: true,
-					command: `certutil -addstore -f Root "${certPath}"`
-				};
+				// Not running as admin - try PowerShell elevation
+				try {
+					const psScript = `Start-Process powershell -ArgumentList '-Command', 'certutil -addstore -f Root \\"${certPath}\\"' -Verb RunAs`;
+					execSync(`powershell -Command "${psScript}"`, { stdio: 'ignore' });
+					// Give it a moment for UAC dialog
+					await new Promise(resolve => setTimeout(resolve, 2000));
+					return {
+						success: true,
+						message: 'Certificate installation prompt shown. Please approve the UAC prompt and restart your browser.',
+						manual: false
+					};
+				} catch (elevateError) {
+					return {
+						success: false,
+						message: `Installation requires Administrator privileges. Please run PowerShell as Administrator and execute:\n\ncertutil -addstore -f Root "${certPath}"`,
+						manual: true,
+						command: `certutil -addstore -f Root "${certPath}"`
+					};
+				}
 			}
 		} else if (platform === 'linux') {
-			// Linux - varies by distro, provide instructions
-			const distroInfo = getLinuxDistro();
-			return {
-				success: false,
-				message: `Linux certificate installation varies by distribution.\n\nFor Debian/Ubuntu:\nsudo cp "${certPath}" /usr/local/share/ca-certificates/\nsudo update-ca-certificates\n\nFor Fedora/RHEL:\nsudo cp "${certPath}" /etc/pki/ca-trust/source/anchors/\nsudo update-ca-trust`,
-				manual: true,
-				distro: distroInfo
-			};
+			// Linux - try pkexec for GUI systems, fall back to manual instructions
+			try {
+				// Try pkexec (polkit) for GUI password prompt
+				const distroInfo = getLinuxDistro();
+
+				// Try Debian/Ubuntu approach first
+				if (fs.existsSync('/usr/local/share/ca-certificates/')) {
+					const installScript = `cp "${certPath}" /usr/local/share/ca-certificates/waveloggate.crt && update-ca-certificates`;
+					execSync(`pkexec sh -c '${installScript}'`, { stdio: 'ignore' });
+					return {
+						success: true,
+						message: 'Certificate installed. Please restart your browser.',
+						manual: false
+					};
+				}
+				// Try Fedora/RHEL approach
+				else if (fs.existsSync('/etc/pki/ca-trust/source/anchors/')) {
+					const installScript = `cp "${certPath}" /etc/pki/ca-trust/source/anchors/waveloggate.crt && update-ca-trust`;
+					execSync(`pkexec sh -c '${installScript}'`, { stdio: 'ignore' });
+					return {
+						success: true,
+						message: 'Certificate installed. Please restart your browser.',
+						manual: false
+					};
+				} else {
+					throw new Error('Unknown certificate location');
+				}
+			} catch (linuxError) {
+				// Fall back to manual instructions
+				return {
+					success: false,
+					message: `Automatic installation failed. Please run these commands in Terminal:\n\nDebian/Ubuntu:\nsudo cp "${certPath}" /usr/local/share/ca-certificates/waveloggate.crt\nsudo update-ca-certificates\n\nFedora/RHEL:\nsudo cp "${certPath}" /etc/pki/ca-trust/source/anchors/waveloggate.crt\nsudo update-ca-trust`,
+					manual: true
+				};
+			}
 		}
 
 		return {

--- a/main.js
+++ b/main.js
@@ -26,6 +26,9 @@ let currentCAT=null;
 var WServer;
 let wsServer;
 let wsClients = new Set();
+let wssServer; // Secure WebSocket server
+let wssClients = new Set(); // Secure WebSocket clients
+let wssHttpsServer; // HTTPS server for secure WebSocket
 let isShuttingDown = false;
 let activeConnections = new Set(); // Track active TCP connections
 let activeHttpRequests = new Set(); // Track active HTTP requests for cancellation
@@ -245,6 +248,19 @@ function shutdownApplication() {
             });
             wsClients.clear();
             wsServer.close();
+        }
+        if (wssServer) {
+            // Close all Secure WebSocket client connections
+            wssClients.forEach(client => {
+                if (client.readyState === WebSocket.OPEN) {
+                    client.close();
+                }
+            });
+            wssClients.clear();
+            wssServer.close();
+            if (wssHttpsServer) {
+                wssHttpsServer.close();
+            }
         }
     } catch (error) {
         console.error('Error during server shutdown:', error);
@@ -967,6 +983,9 @@ function startserver() {
 
 		// Start WebSocket server
 		startWebSocketServer();
+
+		// Start Secure WebSocket server
+		startSecureWebSocketServer();
 	} catch(e) {
 		tomsg('Some other Tool blocks Port 2333 or 54321. Stop it, and restart this');
 	}
@@ -1006,6 +1025,56 @@ function startWebSocketServer() {
 	}
 }
 
+function startSecureWebSocketServer() {
+	if (!certPaths.key || !certPaths.cert) {
+		return;
+	}
+
+	try {
+		// Create HTTPS server first
+		wssHttpsServer = https.createServer({
+			key: certPaths.key,
+			cert: certPaths.cert
+		});
+
+		// Listen on port 54323
+		wssHttpsServer.listen(54323);
+
+		// Attach WebSocket server to the HTTPS server
+		wssServer = new WebSocket.Server({ server: wssHttpsServer });
+
+		wssServer.on('connection', (ws) => {
+			wssClients.add(ws);
+
+			ws.on('close', () => {
+				wssClients.delete(ws);
+			});
+
+			ws.on('error', (error) => {
+				wssClients.delete(ws);
+			});
+
+			// Send current radio status on connection
+			ws.send(JSON.stringify({
+				type: 'welcome',
+				message: 'Connected to WaveLogGate Secure WebSocket server'
+			}));
+			broadcastRadioStatus(currentCAT);
+		});
+
+		wssServer.on('error', (error) => {
+			// Silent error handling
+		});
+
+		wssHttpsServer.on('error', (error) => {
+			// Silent error handling
+		});
+
+	} catch(e) {
+		// Silent error handling
+	}
+}
+
 function broadcastRadioStatus(radioData) {
 	currentCAT=radioData;
 	let message = {
@@ -1022,7 +1091,14 @@ function broadcastRadioStatus(radioData) {
 	}
 
 	const messageStr = JSON.stringify(message);
+	// Broadcast to regular WebSocket clients
 	wsClients.forEach((client) => {
+		if (client.readyState === WebSocket.OPEN) {
+			client.send(messageStr);
+		}
+	});
+	// Broadcast to secure WebSocket clients
+	wssClients.forEach((client) => {
 		if (client.readyState === WebSocket.OPEN) {
 			client.send(messageStr);
 		}

--- a/main.js
+++ b/main.js
@@ -685,8 +685,8 @@ function setupCertificates() {
 		}]);
 
 		// Self-sign the certificate
-		cert.sign(keys.privateKey);
-
+		cert.sign(keys.privateKey, forge.md.sha256.create());
+		
 		// Convert to PEM format
 		const certPem = forge.pki.certificateToPem(cert);
 		const keyPem = forge.pki.privateKeyToPem(keys.privateKey);

--- a/main.js
+++ b/main.js
@@ -201,7 +201,7 @@ function createWindow () {
 			contextIsolation: false,
 			backgroundThrottling: false,
 			nodeIntegration: true,
-			devTools: true, // Enable for debugging auto-updater
+			devTools: !app.isPackaged,
 			enableRemoteModule: true,
 			preload: path.join(__dirname, 'preload.js')
 		}

--- a/main.js
+++ b/main.js
@@ -148,6 +148,24 @@ ipcMain.on("get_ca_cert", async (event) => {
 	event.returnValue = caCert;
 });
 
+ipcMain.on("install_ca_cert", async (event) => {
+	// Attempt to install the CA certificate
+	const result = await installCertificate();
+	event.returnValue = result;
+});
+
+ipcMain.on("get_cert_info", async (event) => {
+	// Return certificate installation info for the UI
+	const userDataPath = app.getPath('userData');
+	const certPath = path.join(userDataPath, 'certs', 'server.crt');
+
+	event.returnValue = {
+		certPath: certPath,
+		platform: process.platform,
+		hasCert: fs.existsSync(certPath)
+	};
+});
+
 function cleanupConnections() {
     console.log('Cleaning up active TCP connections...');
 
@@ -588,7 +606,7 @@ function setupCertificates() {
 			cert: fs.readFileSync(certPath)
 		};
 		console.log('Using existing SSL certificates');
-		return true;
+		return { success: true, newlyGenerated: false };
 	}
 
 	// Generate new certificates
@@ -599,7 +617,7 @@ function setupCertificates() {
 		}
 
 		// Generate self-signed certificate
-		const attrs = [{ name: 'commonName', value: 'WaveLogGate' }];
+		const attrs = [{ name: 'commonName', value: '127.0.0.1' }];
 		const certs = selfsigned.generate(attrs, {
 			days: 3650, // 10 years
 			altNames: [
@@ -621,11 +639,11 @@ function setupCertificates() {
 		};
 
 		console.log('Generated new SSL certificates');
-		return true;
+		return { success: true, newlyGenerated: true };
 	} catch (error) {
 		console.error('Failed to generate certificates:', error);
 		tomsg('Warning: Failed to generate SSL certificates. HTTPS server will not be available.');
-		return false;
+		return { success: false, newlyGenerated: false };
 	}
 }
 
@@ -638,6 +656,103 @@ function getCaCertificate() {
 		return fs.readFileSync(certPath, 'utf8');
 	}
 	return null;
+}
+
+// Install certificate in system trust store
+async function installCertificate() {
+	const { execSync } = require('child_process');
+	const userDataPath = app.getPath('userData');
+	const certPath = path.join(userDataPath, 'certs', 'server.crt');
+
+	if (!fs.existsSync(certPath)) {
+		return {
+			success: false,
+			message: 'Certificate not found. Please restart the application to generate it.',
+			manual: false
+		};
+	}
+
+	const platform = process.platform;
+
+	try {
+		if (platform === 'darwin') {
+			// macOS - try to install in user keychain (no sudo required)
+			// Then provide instruction for system keychain
+			try {
+				// Try user keychain first (no sudo needed)
+				execSync(`security add-trusted-cert -d -r trustRoot -k ~/Library/Keychains/login.keychain-db "${certPath}"`, { stdio: 'ignore' });
+				console.log('Certificate installed in user keychain');
+				return {
+					success: true,
+					message: 'Certificate installed in user keychain. Safari should now trust it.',
+					manual: false
+				};
+			} catch (userError) {
+				// Fallback instructions for system keychain
+				console.log('Could not install in user keychain, providing manual instructions');
+				return {
+					success: false,
+					message: `Automatic installation failed. Please run this command in Terminal:\n\nsudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "${certPath}"`,
+					manual: true,
+					command: `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "${certPath}"`
+				};
+			}
+		} else if (platform === 'win32') {
+			// Windows - use certutil (may require admin)
+			try {
+				execSync(`certutil -addstore -f Root "${certPath}"`, { stdio: 'ignore' });
+				console.log('Certificate installed in Windows trust store');
+				return {
+					success: true,
+					message: 'Certificate installed in Windows trust store.',
+					manual: false
+				};
+			} catch (winError) {
+				return {
+					success: false,
+					message: `Installation requires Administrator privileges. Please run PowerShell as Administrator and execute:\n\ncertutil -addstore -f Root "${certPath}"`,
+					manual: true,
+					command: `certutil -addstore -f Root "${certPath}"`
+				};
+			}
+		} else if (platform === 'linux') {
+			// Linux - varies by distro, provide instructions
+			const distroInfo = getLinuxDistro();
+			return {
+				success: false,
+				message: `Linux certificate installation varies by distribution.\n\nFor Debian/Ubuntu:\nsudo cp "${certPath}" /usr/local/share/ca-certificates/\nsudo update-ca-certificates\n\nFor Fedora/RHEL:\nsudo cp "${certPath}" /etc/pki/ca-trust/source/anchors/\nsudo update-ca-trust`,
+				manual: true,
+				distro: distroInfo
+			};
+		}
+
+		return {
+			success: false,
+			message: 'Unsupported platform for automatic certificate installation.',
+			manual: true
+		};
+	} catch (error) {
+		console.error('Certificate installation error:', error);
+		return {
+			success: false,
+			message: `Installation failed: ${error.message}`,
+			manual: true
+		};
+	}
+}
+
+function getLinuxDistro() {
+	try {
+		const { execSync } = require('child_process');
+		if (fs.existsSync('/etc/os-release')) {
+			const osRelease = fs.readFileSync('/etc/os-release', 'utf8');
+			const match = osRelease.match(/ID=([^\n]+)/);
+			if (match) return match[1];
+		}
+	} catch (e) {
+		// Ignore
+	}
+	return 'unknown';
 }
 
 // Request handler for both HTTP and HTTPS servers
@@ -675,12 +790,22 @@ function createRequestHandler(req, res) {
 function startserver() {
 	try {
 		// Setup SSL certificates
-		const hasCerts = setupCertificates();
+		const certResult = setupCertificates();
 
 		tomsg('Waiting for QSO / Listening on UDP 2333');
 
+		// Prompt for certificate installation if newly generated
+		if (certResult.success && certResult.newlyGenerated) {
+			// Schedule prompt after window is ready
+			setTimeout(() => {
+				if (s_mainWindow && !s_mainWindow.isDestroyed()) {
+					s_mainWindow.webContents.send('prompt_cert_install');
+				}
+			}, 2000);
+		}
+
 		// Create dual-mode HTTP/HTTPS server on port 54321
-		if (hasCerts && certPaths.key && certPaths.cert) {
+		if (certResult.success && certPaths.key && certPaths.cert) {
 			// Create httpolyglot server (handles both HTTP and HTTPS on same port)
 			const serverOptions = {
 				key: certPaths.key,

--- a/main.js
+++ b/main.js
@@ -822,6 +822,16 @@ async function installCertificate() {
 						message: 'Certificate installed. Please restart your browser.',
 						manual: false
 					};
+				}
+				// Try Arch Linux approach
+				else if (fs.existsSync('/etc/ca-certificates/trust-source/anchors/')) {
+					const installScript = `cp "${certPath}" /etc/ca-certificates/trust-source/anchors/waveloggate.crt && update-ca-trust`;
+					execSync(`pkexec sh -c '${installScript}'`, { stdio: 'ignore' });
+					return {
+						success: true,
+						message: 'Certificate installed. Please restart your browser.',
+						manual: false
+					};
 				} else {
 					throw new Error('Unknown certificate location');
 				}
@@ -829,7 +839,7 @@ async function installCertificate() {
 				// Fall back to manual instructions
 				return {
 					success: false,
-					message: `Automatic installation failed. Please run these commands in Terminal:\n\nDebian/Ubuntu:\nsudo cp "${certPath}" /usr/local/share/ca-certificates/waveloggate.crt\nsudo update-ca-certificates\n\nFedora/RHEL:\nsudo cp "${certPath}" /etc/pki/ca-trust/source/anchors/waveloggate.crt\nsudo update-ca-trust`,
+					message: `Automatic installation failed. Please run these commands in Terminal:\n\nDebian/Ubuntu:\nsudo cp "${certPath}" /usr/local/share/ca-certificates/waveloggate.crt\nsudo update-ca-certificates\n\nFedora/RHEL:\nsudo cp "${certPath}" /etc/pki/ca-trust/source/anchors/waveloggate.crt\nsudo update-ca-trust\n\nArch Linux:\nsudo cp "${certPath}" /etc/ca-certificates/trust-source/anchors/waveloggate.crt\nsudo update-ca-trust`,
 					manual: true
 				};
 			}

--- a/main.js
+++ b/main.js
@@ -729,6 +729,86 @@ function getCaCertificate() {
 	return null;
 }
 
+// Check if certificate is installed in system trust store
+function isCertificateInstalled() {
+	const { execSync } = require('child_process');
+	const userDataPath = app.getPath('userData');
+	const certPath = path.join(userDataPath, 'certs', 'server.crt');
+
+	if (!fs.existsSync(certPath)) {
+		return false;
+	}
+
+	const platform = process.platform;
+
+	try {
+		if (platform === 'win32') {
+			// Windows: Check if cert exists in Root store
+			// Use certutil to dump the Root store and search for our cert
+			try {
+				const output = execSync('certutil -store Root', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+				// Check for our certificate's common name (127.0.0.1)
+				return output.includes('CN=127.0.0.1') || output.includes('127.0.0.1');
+			} catch (err) {
+				console.log('Failed to check Windows certificate store:', err.message);
+				return false;
+			}
+		} else if (platform === 'darwin') {
+			// macOS: Check if cert exists in System keychain
+			try {
+				execSync('security find-certificate -c "127.0.0.1" -p /Library/Keychains/System.keychain', { stdio: 'ignore' });
+				return true;
+			} catch (err) {
+				// Also check user keychain as fallback
+				try {
+					execSync('security find-certificate -c "127.0.0.1" -p ~/Library/Keychains/login.keychain-db', { stdio: 'ignore' });
+					return true;
+				} catch (userErr) {
+					return false;
+				}
+			}
+		} else if (platform === 'linux') {
+			// Linux: Check if cert exists in system ca-certificates directories
+			const certContent = fs.readFileSync(certPath, 'utf8');
+			// Calculate a simple hash of the certificate content
+			const crypto = require('crypto');
+			const certHash = crypto.createHash('sha256').update(certContent).digest('hex');
+
+			// Check Debian/Ubuntu location
+			const debPath = '/usr/local/share/ca-certificates/waveloggate.crt';
+			if (fs.existsSync(debPath)) {
+				const existingContent = fs.readFileSync(debPath, 'utf8');
+				const existingHash = crypto.createHash('sha256').update(existingContent).digest('hex');
+				if (certHash === existingHash) return true;
+			}
+
+			// Check Fedora/RHEL location
+			const rhelPath = '/etc/pki/ca-trust/source/anchors/waveloggate.crt';
+			if (fs.existsSync(rhelPath)) {
+				const existingContent = fs.readFileSync(rhelPath, 'utf8');
+				const existingHash = crypto.createHash('sha256').update(existingContent).digest('hex');
+				if (certHash === existingHash) return true;
+			}
+
+			// Check Arch Linux location
+			const archPath = '/etc/ca-certificates/trust-source/anchors/waveloggate.crt';
+			if (fs.existsSync(archPath)) {
+				const existingContent = fs.readFileSync(archPath, 'utf8');
+				const existingHash = crypto.createHash('sha256').update(existingContent).digest('hex');
+				if (certHash === existingHash) return true;
+			}
+
+			return false;
+		}
+
+		// Unknown platform - assume not installed
+		return false;
+	} catch (error) {
+		console.log('Error checking certificate installation:', error.message);
+		return false;
+	}
+}
+
 // Install certificate in system trust store
 async function installCertificate() {
 	const { execSync } = require('child_process');
@@ -969,12 +1049,21 @@ function startserver() {
 
 		tomsg('Waiting for QSO / Listening on UDP 2333');
 
-		// Prompt for certificate installation if newly generated
-		if (certResult.success && certResult.newlyGenerated) {
-			// Schedule prompt after window is ready
-			setTimeout(() => {
-				showCertInstallWindow();
-			}, 2000);
+		// Prompt for certificate installation if:
+		// 1. Cert was just generated, OR
+		// 2. Cert exists but is NOT installed in system trust store
+		if (certResult.success) {
+			const certInstalled = isCertificateInstalled();
+
+			if (certResult.newlyGenerated || !certInstalled) {
+				console.log('Certificate installation prompt needed - newlyGenerated:', certResult.newlyGenerated, 'installed:', certInstalled);
+				// Schedule prompt after window is ready
+				setTimeout(() => {
+					showCertInstallWindow();
+				}, 2000);
+			} else {
+				console.log('Certificate is installed in system trust store');
+			}
 		}
 
 		// Create dual-mode HTTP/HTTPS server on port 54321

--- a/main.js
+++ b/main.js
@@ -448,35 +448,80 @@ function shutdownApplication() {
         // Close all servers
         if (WServer) {
             console.log('Closing UDP server...');
-            WServer.close();
+            try {
+                WServer.close();
+            } catch (e) {
+                console.error('Error closing UDP server:', e);
+            }
+            WServer = null;
         }
         if (qsyServer) {
             console.log('Closing QSY server...');
-            qsyServer.close();
+            try {
+                qsyServer.close();
+            } catch (e) {
+                console.error('Error closing QSY server:', e);
+            }
+            qsyServer = null;
         }
         if (wsServer) {
             console.log('Closing WebSocket server and clients...');
-            // Close all WebSocket client connections
+            // Close all WebSocket client connections with explicit termination
             wsClients.forEach(client => {
-                if (client.readyState === WebSocket.OPEN) {
-                    client.close();
+                try {
+                    if (client.readyState === WebSocket.OPEN || client.readyState === WebSocket.CONNECTING) {
+                        client.close(1001, 'Server shutting down');
+                    }
+                } catch (e) {
+                    // Client may already be closed, try terminate
+                    try {
+                        client.terminate();
+                    } catch (terminateError) {
+                        // Ignore, client is gone
+                    }
                 }
             });
             wsClients.clear();
-            wsServer.close();
+            try {
+                wsServer.close();
+            } catch (e) {
+                console.error('Error closing WebSocket server:', e);
+            }
+            // wsServer will be set to null by the 'close' event handler
         }
         if (wssServer) {
-            // Close all Secure WebSocket client connections
+            console.log('Closing Secure WebSocket server and clients...');
+            // Close all Secure WebSocket client connections with explicit termination
             wssClients.forEach(client => {
-                if (client.readyState === WebSocket.OPEN) {
-                    client.close();
+                try {
+                    if (client.readyState === WebSocket.OPEN || client.readyState === WebSocket.CONNECTING) {
+                        client.close(1001, 'Server shutting down');
+                    }
+                } catch (e) {
+                    // Client may already be closed, try terminate
+                    try {
+                        client.terminate();
+                    } catch (terminateError) {
+                        // Ignore, client is gone
+                    }
                 }
             });
             wssClients.clear();
-            wssServer.close();
-            if (wssHttpsServer) {
-                wssHttpsServer.close();
+            try {
+                wssServer.close();
+            } catch (e) {
+                console.error('Error closing Secure WebSocket server:', e);
             }
+            // wssServer will be set to null by the 'close' event handler
+        }
+        if (wssHttpsServer) {
+            console.log('Closing HTTPS server...');
+            try {
+                wssHttpsServer.close();
+            } catch (e) {
+                console.error('Error closing HTTPS server:', e);
+            }
+            // wssHttpsServer will be set to null by the 'close' event handler
         }
     } catch (error) {
         console.error('Error during server shutdown:', error);
@@ -1342,40 +1387,75 @@ function startserver() {
 
 function startWebSocketServer() {
 	try {
-		wsServer = new WebSocket.Server({ port: 54322, exclusive: true });
+		wsServer = new WebSocket.Server({
+			port: 54322,
+			exclusive: true,
+			clientTracking: true // Enable built-in client tracking
+		});
 
 		wsServer.on('connection', (ws) => {
 			wsClients.add(ws);
 			console.log('WebSocket client connected');
 
-			ws.on('close', () => {
+			// Set up cleanup for this connection
+			const cleanupClient = () => {
 				wsClients.delete(ws);
-			});
+				// Ensure socket is fully cleaned up
+				if (ws.readyState !== WebSocket.CLOSED) {
+					ws.terminate();
+				}
+			};
+
+			ws.on('close', cleanupClient);
 
 			ws.on('error', (error) => {
-				console.error('WebSocket error:', error);
-				wsClients.delete(ws);
+				console.error('WebSocket client error:', error);
+				cleanupClient();
+			});
+
+			// Handle unexpected termination
+			ws.on('unexpected-response', (req, res) => {
+				console.error('WebSocket unexpected response:', res.statusCode);
+				cleanupClient();
 			});
 
 			// Send current radio status on connection
-			ws.send(JSON.stringify({
-				type: 'welcome',
-				message: 'Connected to WaveLogGate WebSocket server'
-			}));
-			broadcastRadioStatus(currentCAT);
+			try {
+				ws.send(JSON.stringify({
+					type: 'welcome',
+					message: 'Connected to WaveLogGate WebSocket server'
+				}));
+				broadcastRadioStatus(currentCAT);
+			} catch (sendError) {
+				console.error('Error sending welcome message:', sendError);
+				cleanupClient();
+			}
 		});
 
 		wsServer.on('error', (error) => {
 			console.error('WebSocket server error:', error);
+			// If server fails critically, nullify it so shutdown knows it's gone
+			if (error.code === 'EADDRINUSE') {
+				console.error('Port 54322 already in use, WebSocket server not started');
+				wsServer = null;
+			}
 		});
 
+		wsServer.on('close', () => {
+			console.log('WebSocket server closed');
+			wsServer = null;
+		});
+
+		console.log('WebSocket server started on port 54322');
 	} catch(e) {
 		console.error('WebSocket server startup error:', e);
+		wsServer = null;
 	}
 }
 
 function startSecureWebSocketServer() {
 	if (!certPaths.key || !certPaths.cert) {
+		console.log('No SSL certificates available, skipping secure WebSocket server');
 		return;
 	}
 
@@ -1386,41 +1466,97 @@ function startSecureWebSocketServer() {
 			cert: certPaths.cert
 		});
 
-		// Listen on port 54323
-		wssHttpsServer.listen(54323);
-
-		// Attach WebSocket server to the HTTPS server
-		wssServer = new WebSocket.Server({ server: wssHttpsServer });
-
-		wssServer.on('connection', (ws) => {
-			wssClients.add(ws);
-
-			ws.on('close', () => {
-				wssClients.delete(ws);
-			});
-
-			ws.on('error', (error) => {
-				wssClients.delete(ws);
-			});
-
-			// Send current radio status on connection
-			ws.send(JSON.stringify({
-				type: 'welcome',
-				message: 'Connected to WaveLogGate Secure WebSocket server'
-			}));
-			broadcastRadioStatus(currentCAT);
-		});
-
-		wssServer.on('error', (error) => {
-			// Silent error handling
-		});
-
+		// Handle HTTPS server errors
 		wssHttpsServer.on('error', (error) => {
-			// Silent error handling
+			console.error('HTTPS server error:', error);
+			if (error.code === 'EADDRINUSE') {
+				console.error('Port 54323 already in use, secure WebSocket server not started');
+				wssHttpsServer = null;
+				wssServer = null;
+			}
+		});
+
+		wssHttpsServer.on('close', () => {
+			console.log('HTTPS server closed');
+			wssHttpsServer = null;
+		});
+
+		// Listen on port 54323 with callback
+		wssHttpsServer.listen(54323, () => {
+			console.log('HTTPS server listening on port 54323');
+
+			// Attach WebSocket server to the HTTPS server
+			wssServer = new WebSocket.Server({ server: wssHttpsServer, clientTracking: true });
+
+			wssServer.on('connection', (ws) => {
+				wssClients.add(ws);
+				console.log('Secure WebSocket client connected');
+
+				// Set up cleanup for this connection
+				const cleanupClient = () => {
+					wssClients.delete(ws);
+					// Ensure socket is fully cleaned up
+					if (ws.readyState !== WebSocket.CLOSED) {
+						ws.terminate();
+					}
+				};
+
+				ws.on('close', cleanupClient);
+
+				ws.on('error', (error) => {
+					console.error('Secure WebSocket client error:', error);
+					cleanupClient();
+				});
+
+				// Handle unexpected termination
+				ws.on('unexpected-response', (req, res) => {
+					console.error('Secure WebSocket unexpected response:', res.statusCode);
+					cleanupClient();
+				});
+
+				// Send current radio status on connection
+				try {
+					ws.send(JSON.stringify({
+						type: 'welcome',
+						message: 'Connected to WaveLogGate Secure WebSocket server'
+					}));
+					broadcastRadioStatus(currentCAT);
+				} catch (sendError) {
+					console.error('Error sending secure welcome message:', sendError);
+					cleanupClient();
+				}
+			});
+
+			wssServer.on('error', (error) => {
+				console.error('Secure WebSocket server error:', error);
+				// If the WebSocket server fails, we need to clean up the HTTPS server too
+				if (wssHttpsServer) {
+					wssHttpsServer.close();
+					wssHttpsServer = null;
+				}
+				wssServer = null;
+			});
+
+			wssServer.on('close', () => {
+				console.log('Secure WebSocket server closed');
+				wssServer = null;
+			});
+
+			console.log('Secure WebSocket server started on port 54323');
 		});
 
 	} catch(e) {
-		// Silent error handling
+		console.error('Secure WebSocket server startup error:', e);
+		// Clean up any partially created resources
+		if (wssHttpsServer) {
+			try {
+				wssHttpsServer.close();
+			} catch (closeError) {
+				// Ignore errors during cleanup
+			}
+			wssHttpsServer = null;
+		}
+		wssServer = null;
 	}
 }
 

--- a/main.js
+++ b/main.js
@@ -542,8 +542,20 @@ app.on('will-quit', () => {
 });
 
 if (!gotTheLock) {
-	app.quit();
+	// Another instance is running - signal it to quit and relaunch
+	console.log('Another instance is running, requesting it to quit...');
+	// Wait for the old instance to quit, then relaunch
+	setTimeout(() => {
+		app.relaunch();
+		app.exit(0);
+	}, 1000);
 } else {
+	// Handle second instance trying to start - quit to let new instance take over
+	app.on('second-instance', (event, commandLine, workingDirectory) => {
+		console.log('Second instance detected, quitting to let new instance take over...');
+		app.quit();
+	});
+
 	startserver();
 	app.whenReady().then(() => {
 		if (!sleepable) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "electron-squirrel-startup": "^1.0.1",
         "httpolyglot": "^0.1.2",
         "jquery": "^3.7.1",
+        "node-forge": "^1.3.1",
         "popper.js": "^1.16.1",
-        "selfsigned": "^2.4.1",
         "tcadif": "^2.3.0",
         "ws": "^8.18.3",
         "xml2js": "^0.6.2"
@@ -1711,18 +1711,10 @@
       "version": "22.19.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/node-forge": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -5923,9 +5915,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -6994,19 +6986,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/selfsigned": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node-forge": "^1.3.0",
-        "node-forge": "^1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -7718,6 +7697,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unique-filename": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,14 @@
 {
   "name": "wavelog-gate-by-dj7nt",
-  "version": "1.1.15",
+  "version": "1.1.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wavelog-gate-by-dj7nt",
-      "version": "1.1.15",
+      "version": "1.1.50",
       "dependencies": {
         "bootstrap": "^4.6.2",
-        "dgram": "^1.0.1",
-        "electron-json-config": "^2.1.0",
         "electron-json-storage": "^4.6.0",
         "electron-squirrel-startup": "^1.0.1",
         "httpolyglot": "^0.1.2",
@@ -3074,13 +3072,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/dgram": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dgram/-/dgram-1.0.1.tgz",
-      "integrity": "sha512-zJVFL1EWfKtE0z2VN6qfpn/a+qG1viEzcwJA0EjtzS76ONSE3sEyWBwEbo32hS4IFw/EWVuWN+8b89aPW6It2A==",
-      "deprecated": "npm is holding this package for security reasons. As it's a core Node module, we will not transfer it over to other users. You may safely remove the package from your dependencies.",
-      "license": "ISC"
-    },
     "node_modules/dir-compare": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
@@ -3554,12 +3545,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/electron-json-config": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/electron-json-config/-/electron-json-config-2.1.0.tgz",
-      "integrity": "sha512-27Ir6UrULSBO326p+9kl3zCPjnKsFsfA6Z0D2Pu6JNQ+7Xkx0GvDq+RhqkfpY66/a7uQbzSxsMuLpVkEdS6nww==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/electron-json-storage": {
       "version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,22 @@
 {
   "name": "wavelog-gate-by-dj7nt",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wavelog-gate-by-dj7nt",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "dependencies": {
-        "@electron-forge/maker-dmg": "^7.10.2",
         "bootstrap": "^4.6.2",
         "dgram": "^1.0.1",
         "electron-json-config": "^2.1.0",
         "electron-json-storage": "^4.6.0",
         "electron-squirrel-startup": "^1.0.1",
+        "httpolyglot": "^0.1.2",
         "jquery": "^3.7.1",
         "popper.js": "^1.16.1",
+        "selfsigned": "^2.4.1",
         "tcadif": "^2.3.0",
         "ws": "^8.18.3",
         "xml2js": "^0.6.2"
@@ -23,12 +24,13 @@
       "devDependencies": {
         "@electron-forge/cli": "^7.10.2",
         "@electron-forge/maker-deb": "^7.10.2",
+        "@electron-forge/maker-dmg": "^7.10.2",
         "@electron-forge/maker-rpm": "^7.10.2",
         "@electron-forge/maker-squirrel": "^7.10.2",
         "@electron-forge/maker-zip": "^7.10.2",
         "@electron-forge/plugin-auto-unpack-natives": "^7.10.2",
         "@electron-forge/publisher-github": "^7.10.2",
-        "electron": "^36.9.5",
+        "electron": "^39.0.0",
         "electron-rebuild": "^3.2.9"
       }
     },
@@ -154,6 +156,7 @@
       "version": "7.10.2",
       "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.10.2.tgz",
       "integrity": "sha512-1QN4qnPVTjo+qWYG+s0kYv7XcuIowsPVvbl718FgJUcvkxyRjUA6kWHjFxRvdV6g7Sa2PzZBF+/Mrjpws1lehQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@electron-forge/shared-types": "7.10.2",
@@ -185,6 +188,7 @@
       "version": "7.10.2",
       "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.10.2.tgz",
       "integrity": "sha512-ksSX6/Ioxa3h3rEGIg26qfDcJgB3aFGivitRdSkEnzUCLWJSUoThEwLToA7CAq4J/4ZREK0PDJ7FPsB+F8CYfQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@electron-forge/maker-base": "7.10.2",
@@ -318,6 +322,7 @@
       "version": "7.10.2",
       "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.10.2.tgz",
       "integrity": "sha512-e2pd9RsdbKwsNf6UtKoolmJGy92Nc0/XO4SI91doV8cM954hM2XSYz3VHoqXebMFAF1JDfXoEUt6UCRbEDgMgw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@electron-forge/tracer": "7.10.2",
@@ -414,6 +419,7 @@
       "version": "7.10.2",
       "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.10.2.tgz",
       "integrity": "sha512-jhLLQbttfZViSOYn/3SJc8HML+jNZAytPVJwgGGd3coUiFysWJ2Xald99iqOiouPAhIigBfNPxQb/q/EbcDu4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chrome-trace-event": "^1.0.3"
@@ -426,6 +432,7 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
       "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^5.0.0",
@@ -443,6 +450,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -452,6 +460,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
       "integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
@@ -473,6 +482,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -487,6 +497,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -496,6 +507,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -505,6 +517,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -514,6 +527,7 @@
       "version": "10.2.0-electron.1",
       "resolved": "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
       "integrity": "sha512-lBSgDMQqt7QWMuIjS8zNAq5FI5o5RVBAcJUGWGI6GgoQITJt3msAkUrHp8YHj3RTVE+h70ndqMGqURjp3IfRyQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
@@ -538,6 +552,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -548,6 +563,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -567,6 +583,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -579,6 +596,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
       "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
@@ -593,6 +611,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
@@ -608,6 +627,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
       "integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "compare-version": "^0.1.2",
@@ -629,6 +649,7 @@
       "version": "18.4.4",
       "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.4.4.tgz",
       "integrity": "sha512-fTUCmgL25WXTcFpM1M72VmFP8w3E4d+KNzWxmTDRpvwkfn/S206MAtM2cy0GF78KS9AwASMOUmlOIzCHeNxcGQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@electron/asar": "^3.2.13",
@@ -667,6 +688,7 @@
       "version": "11.3.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
       "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -681,6 +703,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.2.tgz",
       "integrity": "sha512-19/KbIR/DAxbsCkiaGMXIdPnMCJLkcf8AvGnduJtWBs/CBwiAjY1apCqOLVxrXg+rtXFCngbXhBanWjxLUt1Mg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@electron/node-gyp": "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
@@ -709,6 +732,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
       "integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@electron/asar": "^3.3.1",
@@ -727,6 +751,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -736,6 +761,7 @@
       "version": "11.3.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
       "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -750,6 +776,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -765,6 +792,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
       "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "cross-dirname": "^0.1.0",
@@ -784,6 +812,7 @@
       "version": "11.3.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
       "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -798,6 +827,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/checkbox": {
@@ -1105,6 +1135,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
       "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1165,6 +1196,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
       "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promisify": "^1.1.3",
@@ -1179,6 +1211,7 @@
       "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
       "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
       "deprecated": "This functionality has been moved to @npmcli/fs",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mkdirp": "^1.0.4",
@@ -1192,6 +1225,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -1205,6 +1239,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -1542,6 +1577,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1554,6 +1590,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
@@ -1566,6 +1603,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -1575,6 +1613,7 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@types/appdmg/-/appdmg-0.5.5.tgz",
       "integrity": "sha512-G+n6DgZTZFOteITE30LnWj+HRVIGr7wMlAiLWOO02uJFWVEitaPU9JVXm9wJokkgshBawb2O1OykdcsmkkZfgg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1585,6 +1624,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
@@ -1637,6 +1677,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1650,6 +1691,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1674,10 +1716,20 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1694,6 +1746,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1872,6 +1925,7 @@
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
       "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -1895,6 +1949,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/acorn": {
@@ -1928,6 +1983,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -1940,6 +1996,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
@@ -1952,6 +2009,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clean-stack": "^2.0.0",
@@ -2030,6 +2088,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2039,6 +2098,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2054,6 +2114,7 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.6.tgz",
       "integrity": "sha512-GRmFKlCG+PWbcYF4LUNonTYmy0GjguDy6Jh9WP8mpd0T6j80XIJyXBiWlD0U+MLNhqV9Nhx49Gl9GpVToulpLg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2105,6 +2166,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -2112,6 +2174,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
@@ -2121,6 +2184,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
       "integrity": "sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -2136,6 +2200,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
       "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2146,6 +2211,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2183,6 +2249,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -2194,6 +2261,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/boolean": {
@@ -2201,6 +2269,7 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -2236,6 +2305,7 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
       "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2304,6 +2374,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2328,6 +2399,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -2344,6 +2416,7 @@
       "version": "16.1.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
       "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/fs": "^2.1.0",
@@ -2373,6 +2446,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2383,6 +2457,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -2402,6 +2477,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -2414,6 +2490,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -2427,6 +2504,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -2442,6 +2520,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2453,6 +2532,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -2473,6 +2553,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -2485,6 +2566,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
@@ -2494,6 +2576,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -2512,6 +2595,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -2548,6 +2632,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2571,6 +2656,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -2580,6 +2666,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
@@ -2589,6 +2676,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2598,6 +2686,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
       "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^4.0.0"
@@ -2613,6 +2702,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2625,6 +2715,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
       "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "slice-ansi": "^5.0.0",
@@ -2651,6 +2742,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -2665,12 +2757,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2680,6 +2774,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2694,6 +2789,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2711,6 +2807,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -2720,6 +2817,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -2732,6 +2830,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2744,6 +2843,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
@@ -2760,6 +2860,7 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -2776,6 +2877,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
       "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2798,12 +2900,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2842,6 +2946,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2859,6 +2964,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -2874,6 +2980,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2886,6 +2993,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
@@ -2898,6 +3006,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2907,6 +3016,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2925,6 +3035,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2957,6 +3068,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2966,6 +3078,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -2980,6 +3093,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
       "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimatch": "^3.0.5",
@@ -2990,6 +3104,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
       "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3002,12 +3117,13 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "36.9.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-36.9.5.tgz",
-      "integrity": "sha512-1UCss2IqxqujSzg/2jkRjuiT3G+EEXgd6UKB5kUekwQW1LJ6d4QCr8YItfC3Rr9VIGRDJ29eOERmnRNO1Eh+NA==",
+      "version": "39.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.3.0.tgz",
+      "integrity": "sha512-ZA2Cmu5Vs8zeuZBr71XWZ5vgm7lRDB9N50oV6ee7YocITyxRxx/apWFKY48Sxyn0gzVlX+6YQc3CS1PtYIkGUg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3263,6 +3379,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/electron-installer-dmg/-/electron-installer-dmg-5.0.1.tgz",
       "integrity": "sha512-qOa1aAQdX57C+vzhDk3549dd/PRlNL4F8y736MTD1a43qptD+PvHY97Bo9gSf+OZ8iUWE7BrYSpk/FgLUe40EA==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -3677,12 +3794,14 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encode-utf8": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
       "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -3690,6 +3809,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -3713,6 +3833,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3722,12 +3843,14 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -3737,6 +3860,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3747,6 +3871,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3764,6 +3889,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -3771,6 +3897,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3780,6 +3907,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3840,6 +3968,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -3856,7 +3985,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^6.0.0",
@@ -3875,7 +4004,7 @@
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
       "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
@@ -3892,7 +4021,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3902,7 +4031,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -3912,7 +4041,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^1.0.0"
@@ -3925,7 +4054,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3935,14 +4064,14 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/execa/node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3955,6 +4084,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/external-editor": {
@@ -3976,6 +4106,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -3996,6 +4127,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -4062,6 +4194,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -4071,6 +4204,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -4080,6 +4214,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
       "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "filename-reserved-regex": "^2.0.0",
@@ -4127,6 +4262,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-2.0.0.tgz",
       "integrity": "sha512-dz4HxH6pOvbUzZpZ/yXhafjbR2I8cenK5xL0KtBFb7U2ADsR+OwXifnxZjij/pZWF775uSCMzWVd+jDik2H2IA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -4140,6 +4276,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
       "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4150,6 +4287,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -4164,6 +4302,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -4176,6 +4315,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.2.1.tgz",
       "integrity": "sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4186,6 +4326,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.3.1.tgz",
       "integrity": "sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4206,6 +4347,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4215,6 +4357,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/galactus/-/galactus-1.0.0.tgz",
       "integrity": "sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -4298,6 +4441,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4308,6 +4452,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4318,6 +4463,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4342,6 +4488,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-package-info/-/get-package-info-1.0.0.tgz",
       "integrity": "sha512-SCbprXGAPdIhKAXiG+Mk6yeoFH61JlYunqdFQFHDtLjJlDjFf6x07dsS8acO+xWt52jpdVo49AlVDnUVK1sDNw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bluebird": "^3.1.1",
@@ -4357,6 +4504,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -4366,13 +4514,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -4426,6 +4575,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -4460,6 +4610,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4477,6 +4628,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -4490,6 +4642,7 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
@@ -4521,6 +4674,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4530,6 +4684,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4550,6 +4705,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4562,18 +4718,21 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
@@ -4588,6 +4747,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -4597,10 +4757,19 @@
         "node": ">=10.19.0"
       }
     },
+    "node_modules/httpolyglot": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/httpolyglot/-/httpolyglot-0.1.2.tgz",
+      "integrity": "sha512-ouHI1AaQMLgn4L224527S5+vq6hgvqPteurVfbm7ChViM3He2Wa8KP1Ny7pTYd7QKnDSPKcN8JYfC8r/lmsE3A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -4614,6 +4783,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
@@ -4636,6 +4806,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4656,6 +4827,7 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
       "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -4669,6 +4841,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
       "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -4688,6 +4861,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4697,6 +4871,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/inflight": {
@@ -4740,6 +4915,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4749,12 +4925,14 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -4780,6 +4958,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4805,6 +4984,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4814,12 +4994,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-my-ip-valid": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
       "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -4827,6 +5009,7 @@
       "version": "2.20.6",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
       "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4851,6 +5034,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -4858,7 +5042,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4868,6 +5052,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4880,6 +5065,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
       "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8.0.0"
@@ -4892,6 +5078,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/jest-worker": {
@@ -4946,6 +5133,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -4966,6 +5154,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -4973,6 +5162,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -4985,6 +5175,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -4995,6 +5186,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
       "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5004,6 +5196,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -5013,6 +5206,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-7.0.2.tgz",
       "integrity": "sha512-rJysbR9GKIalhTbVL2tYbF2hVyDnrf7pFUZBwjPaMIdadYHmeT+EVi/Bu3qd7ETQPahTotg2WRCatXwRBW554g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cli-truncate": "^3.1.0",
@@ -5030,6 +5224,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5042,6 +5237,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5054,6 +5250,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -5069,6 +5266,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -5086,6 +5284,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha512-3p6ZOGNbiX4CdvEd1VcE6yi78UrGNpjHO33noGwHCnT/o2fyllJDepsm8+mFFv/DvtwFHht5HIHSyOy5a+ChVQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -5153,12 +5352,14 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -5175,6 +5376,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
       "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^5.0.0",
@@ -5194,6 +5396,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
       "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^1.0.2"
@@ -5209,6 +5412,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5221,6 +5425,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5233,6 +5438,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -5248,6 +5454,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -5260,6 +5467,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -5277,6 +5485,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5286,6 +5495,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -5314,6 +5524,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.12.tgz",
       "integrity": "sha512-yiLHa7cfJcGRFq4FrR4tMlpNHb4Vy4mWnpajlSSIFM5k4Lv8/7BbbDLzCAVogWNl0LlLhizRp1drXv0hK9h0Yw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5328,6 +5539,7 @@
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
       "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
@@ -5368,6 +5580,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5450,6 +5663,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5459,6 +5673,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5489,6 +5704,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -5501,6 +5717,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
       "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -5513,6 +5730,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
       "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.1.6",
@@ -5530,6 +5748,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
       "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -5542,6 +5761,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -5554,6 +5774,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -5566,6 +5787,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
@@ -5591,12 +5813,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/murmur-32": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.2.0.tgz",
       "integrity": "sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5619,6 +5843,7 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz",
       "integrity": "sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -5626,6 +5851,7 @@
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
       "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5642,13 +5868,14 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abi": {
       "version": "3.85.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
       "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -5668,6 +5895,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
       "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -5692,6 +5920,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp": {
@@ -5760,6 +5997,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
       "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "abbrev": "^1.0.0"
@@ -5775,6 +6013,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^2.1.4",
@@ -5787,6 +6026,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -5796,6 +6036,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5808,7 +6049,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^2.0.0"
@@ -5821,7 +6062,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5848,6 +6089,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5867,6 +6109,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -5882,6 +6125,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.1.0",
@@ -5905,6 +6149,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
@@ -5917,6 +6162,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
@@ -5930,6 +6176,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/os-tmpdir": {
@@ -5946,6 +6193,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5965,7 +6213,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5985,6 +6233,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -6016,6 +6265,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "aggregate-error": "^3.0.0"
@@ -6031,6 +6281,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6040,6 +6291,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-2.0.0.tgz",
       "integrity": "sha512-yx5DfvkN8JsHL2xk2Os9oTia467qnvRgey4ahSm2X8epehBLx/gWLcy5KI+Y36ful5DzGbCS6RazqZGgy1gHNw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "author-regex": "^1.0.0"
@@ -6052,6 +6304,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
       "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6062,12 +6315,14 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
       "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
+      "dev": true,
       "optional": true
     },
     "node_modules/parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "error-ex": "^1.2.0"
@@ -6080,7 +6335,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6099,6 +6354,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6108,12 +6364,14 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.0.0"
@@ -6126,6 +6384,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-1.0.1.tgz",
       "integrity": "sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14",
@@ -6140,6 +6399,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -6166,6 +6426,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6175,6 +6436,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
       "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -6201,6 +6463,7 @@
       "version": "1.0.0-alpha.6",
       "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
       "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^9.4.0"
@@ -6216,6 +6479,7 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
@@ -6225,6 +6489,7 @@
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -6240,6 +6505,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
       "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -6249,6 +6515,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6258,12 +6525,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "err-code": "^2.0.2",
@@ -6277,6 +6546,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -6308,6 +6578,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6320,6 +6591,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz",
       "integrity": "sha512-4jY0yoEaQ5v9StCl5kZbNIQlg1QheIDBrdkDn53EynpPb9FgO6//p3X/tgMnrC45XN6QZCzU1Xz/+pSSsJBpRw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6341,6 +6613,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
       "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
@@ -6353,6 +6626,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha512-eFIBOPW7FGjzBuk3hdXEuNSiTZS/xEMlH49HxMyzb0hyPfu4EhVjT2DH32K1hSSmVq4sebAWnZuuY5auISUTGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "load-json-file": "^2.0.0",
@@ -6367,6 +6641,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha512-1orxQfbWGUiTn9XsPlChs6rLie/AV9jwZTGmu2NZw/CUDJQchXJFYE0Fq5j7+n558T1JhDWLdhyd1Zj+wLY//w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^2.0.0",
@@ -6380,6 +6655,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^2.0.0"
@@ -6392,6 +6668,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^2.0.0",
@@ -6405,6 +6682,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^1.0.0"
@@ -6417,6 +6695,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^1.1.0"
@@ -6429,6 +6708,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6438,6 +6718,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6465,6 +6746,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -6475,6 +6757,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6494,6 +6777,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resedit/-/resedit-2.0.3.tgz",
       "integrity": "sha512-oTeemxwoMuxxTYxXUwjkrOPfngTQehlv0/HoYFNkB4uzsP1Un1A9nI8JQKGOFkxpqkC7qkMs0lUsGrvUlbLNUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pe-library": "^1.0.1"
@@ -6511,6 +6795,7 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -6531,12 +6816,14 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/responselike": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
@@ -6549,6 +6836,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
@@ -6565,12 +6853,14 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -6591,6 +6881,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rimraf": {
@@ -6610,6 +6901,7 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -6652,6 +6944,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6672,7 +6965,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -6701,10 +6994,24 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6717,6 +7024,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -6724,6 +7032,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6740,6 +7049,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -6770,6 +7080,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6782,6 +7093,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6804,6 +7116,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
       "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.0.0",
@@ -6820,6 +7133,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6832,6 +7146,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -6842,6 +7157,7 @@
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.0.1",
@@ -6856,6 +7172,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
       "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^6.0.2",
@@ -6891,6 +7208,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -6901,12 +7219,14 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -6917,12 +7237,14 @@
       "version": "3.0.22",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
       "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -6930,6 +7252,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
       "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.1.1"
@@ -6942,6 +7265,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
+      "dev": true,
       "license": "Unlicense",
       "optional": true,
       "engines": {
@@ -6952,6 +7276,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -6961,6 +7286,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -6978,6 +7304,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6990,6 +7317,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -7005,6 +7333,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7017,6 +7346,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7026,7 +7356,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7036,6 +7366,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.2"
@@ -7048,6 +7379,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -7057,6 +7389,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.0"
@@ -7069,6 +7402,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -7081,6 +7415,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7107,6 +7442,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
       "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -7124,6 +7460,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -7133,6 +7470,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -7288,6 +7626,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
       "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7301,6 +7640,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
       "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -7328,6 +7668,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.2"
@@ -7340,6 +7681,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -7382,6 +7724,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
       "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "unique-slug": "^3.0.0"
@@ -7394,6 +7737,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
       "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
@@ -7413,6 +7757,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -7422,6 +7767,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
       "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+      "dev": true,
       "license": "MIT or GPL-2.0",
       "optional": true,
       "engines": {
@@ -7477,12 +7823,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
@@ -7507,6 +7855,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
@@ -7594,6 +7943,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7775,6 +8125,7 @@
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
@@ -7784,6 +8135,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -7794,6 +8146,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -7803,12 +8156,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -7827,6 +8182,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7836,12 +8192,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7851,6 +8209,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7865,6 +8224,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -7875,6 +8235,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wavelog-gate-by-dj7nt",
-  "version": "1.1.50",
+  "version": "1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wavelog-gate-by-dj7nt",
-      "version": "1.1.50",
+      "version": "1.2",
       "dependencies": {
         "bootstrap": "^4.6.2",
         "electron-json-storage": "^4.6.0",
@@ -972,7 +972,6 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -1265,7 +1264,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -1948,7 +1946,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2015,7 +2012,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2345,7 +2341,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3782,6 +3777,31 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -5103,8 +5123,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -6430,7 +6449,6 @@
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
       "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -7839,7 +7857,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gateway for connecting WSJT-* and FLRig to Wavelog",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.1.15",
+  "version": "1.1.51",
   "author": "DJ7NT",
   "scripts": {
     "start": "electron-forge start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gateway for connecting WSJT-* and FLRig to Wavelog",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "author": "DJ7NT",
   "scripts": {
     "start": "electron-forge start",
@@ -19,8 +19,10 @@
     "electron-json-config": "^2.1.0",
     "electron-json-storage": "^4.6.0",
     "electron-squirrel-startup": "^1.0.1",
+    "httpolyglot": "^0.1.2",
     "jquery": "^3.7.1",
     "popper.js": "^1.16.1",
+    "selfsigned": "^2.4.1",
     "tcadif": "^2.3.0",
     "ws": "^8.18.3",
     "xml2js": "^0.6.2"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gateway for connecting WSJT-* and FLRig to Wavelog",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.1.51",
+  "version": "1.1.52",
   "author": "DJ7NT",
   "scripts": {
     "start": "electron-forge start",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
   },
   "dependencies": {
     "bootstrap": "^4.6.2",
-    "dgram": "^1.0.1",
-    "electron-json-config": "^2.1.0",
     "electron-json-storage": "^4.6.0",
     "electron-squirrel-startup": "^1.0.1",
     "httpolyglot": "^0.1.2",
@@ -38,5 +36,13 @@
     "@electron-forge/publisher-github": "^7.10.2",
     "electron": "^39.0.0",
     "electron-rebuild": "^3.2.9"
+  },
+  "build": {
+    "publish": [{
+      "provider": "github"
+    }],
+    "win": {
+      "target": "squirrel"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     "electron-squirrel-startup": "^1.0.1",
     "httpolyglot": "^0.1.2",
     "jquery": "^3.7.1",
+    "node-forge": "^1.3.1",
     "popper.js": "^1.16.1",
-    "selfsigned": "^2.4.1",
     "tcadif": "^2.3.0",
     "ws": "^8.18.3",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.10.2",
-    "@electron-forge/maker-dmg": "^7.10.2",
     "@electron-forge/maker-deb": "^7.10.2",
+    "@electron-forge/maker-dmg": "^7.10.2",
     "@electron-forge/maker-rpm": "^7.10.2",
     "@electron-forge/maker-squirrel": "^7.10.2",
     "@electron-forge/maker-zip": "^7.10.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gateway for connecting WSJT-* and FLRig to Wavelog",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.1.52",
+  "version": "1.2",
   "author": "DJ7NT",
   "scripts": {
     "start": "electron-forge start",

--- a/renderer.js
+++ b/renderer.js
@@ -713,4 +713,10 @@ async function switchToSelectedProfile() {
 	active_cfg = selectedProfileIndex;
 	await load_config();
 	$('#profileModal').modal('hide');
+
+	// Reset test button to default state (no test run on new profile yet)
+	$("#test").removeClass('btn-success');
+	$("#test").removeClass('btn-danger');
+	$("#test").addClass('btn-primary');
+	$("#msg2").hide();
 }

--- a/renderer.js
+++ b/renderer.js
@@ -148,6 +148,11 @@ $(document).ready(function() {
 		cleanup();
 	});
 
+	// Handle certificate installation prompt
+	ipcRenderer.on('prompt_cert_install', () => {
+		showCertInstallPrompt();
+	});
+
 	// Dropdown change handler
 	$('#radio_type').change(function() {
 		updateRadioFields();
@@ -481,6 +486,86 @@ function cleanup() {
 
 	// Clean up TCP connections
 	cleanupConnections();
+}
+
+function showCertInstallPrompt() {
+	const certInfo = ipcRenderer.sendSync('get_cert_info');
+
+	let message = `WaveLogGate has generated a self-signed SSL certificate for HTTPS support.\n\n`;
+	message += `To allow Safari/ browsers to connect to WaveLogGate via HTTPS without warnings, `;
+	message += `the certificate needs to be installed in your system's trust store.\n\n`;
+	message += `Certificate location:\n${certInfo.certPath}\n\n`;
+	message += `Would you like to install the certificate now?`;
+
+	// Use Bootstrap modal for better UI
+	const modalHtml = `
+<div class="modal fade" id="certInstallModal" tabindex="-1" role="dialog">
+	<div class="modal-dialog" role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title">Install SSL Certificate</h5>
+			</div>
+			<div class="modal-body">
+				<p>WaveLogGate has generated a self-signed SSL certificate for HTTPS support.</p>
+				<p>To allow browsers (especially Safari) to connect to WaveLogGate via HTTPS without security warnings, the certificate needs to be installed in your system's trust store.</p>
+				<p><strong>Certificate location:</strong><br><code>${certInfo.certPath}</code></p>
+				<p>Would you like to install the certificate now?</p>
+			</div>
+			<div class="modal-footer">
+				<button type="button" class="btn btn-secondary" data-dismiss="modal">Later</button>
+				<button type="button" class="btn btn-primary" id="installCertBtn">Install Certificate</button>
+			</div>
+		</div>
+	</div>
+</div>`;
+
+	// Remove existing modal if present
+	$('#certInstallModal').remove();
+
+	// Add modal to body
+	$('body').append(modalHtml);
+
+	// Show modal
+	$('#certInstallModal').modal('show');
+
+	// Handle install button click
+	$('#installCertBtn').one('click', async () => {
+		$('#installCertBtn').prop('disabled', true).text('Installing...');
+
+		const result = ipcRenderer.sendSync('install_ca_cert');
+
+		$('#certInstallModal').modal('hide');
+
+		// Show result alert
+		if (result.success) {
+			showAlert('success', 'Certificate installed successfully! Safari and other browsers should now trust the WaveLogGate HTTPS connection.');
+		} else {
+			let alertMsg = '<strong>Automatic installation failed.</strong><br><br>';
+			alertMsg += result.message.replace(/\n/g, '<br>');
+			showAlert('warning', alertMsg);
+		}
+	});
+}
+
+function showAlert(type, message) {
+	const alertClass = type === 'success' ? 'alert-success' : type === 'warning' ? 'alert-warning' : 'alert-info';
+	const alertHtml = `
+<div class="alert ${alertClass} alert-dismissible fade show mt-2" role="alert">
+	${message}
+	<button type="button" class="close" data-dismiss="alert" aria-label="Close">
+		<span aria-hidden="true">&times;</span>
+	</button>
+</div>`;
+
+	// Add to the status tab's log div
+	$('#log').prepend(alertHtml);
+
+	// Auto-hide after 10 seconds for success messages
+	if (type === 'success') {
+		setTimeout(() => {
+			$('#log .alert').first().alert('close');
+		}, 10000);
+	}
 }
 
 function updateUtcTime() {

--- a/renderer.js
+++ b/renderer.js
@@ -32,18 +32,7 @@ $(document).ready(function() {
 	load_config();
 
 	bt_toggle.addEventListener('click', async () => {
-		if ($("#toggle").html() == '1') {
-			$("#toggle").html("2");
-			active_cfg=1;
-			await load_config();
-		} else {
-			$("#toggle").html("1");
-			active_cfg=0;
-			await load_config();
-		}
-		$("#test").removeClass('btn-success');
-		$("#test").removeClass('btn-danger');
-		$("#test").addClass('btn-primary');
+		openProfileManager();
 	});
 
 	bt_save.addEventListener('click', async () => {
@@ -152,11 +141,36 @@ $(document).ready(function() {
 	$('#radio_type').change(function() {
 		updateRadioFields();
 	});
+
+	// Profile manager modal event listeners
+	$('#btnCreateProfile').click(createProfile);
+	$('#btnSelectProfile').click(switchToSelectedProfile);
+	$('#newProfileName').keypress((e) => {
+		if (e.which === 13) createProfile();
+	});
+
+	// Use event delegation for dynamically created radio buttons
+	$('#profileList').on('change', 'input[type="radio"]', function() {
+		selectedProfileIndex = parseInt($(this).val());
+	});
+
+	// Use event delegation for rename and delete buttons
+	$('#profileList').on('click', '.btn-rename', function() {
+		const index = parseInt($(this).closest('.list-group-item').data('index'));
+		renameProfile(index);
+	});
+
+	$('#profileList').on('click', '.btn-delete', function() {
+		const index = parseInt($(this).closest('.list-group-item').data('index'));
+		deleteProfile(index);
+	});
 });
 
 async function load_config() {
-	cfg=await ipcRenderer.sendSync("get_config", active_cfg);
-	$("#toggle").html((cfg.profile || 0)+1);
+	cfg=await ipcRenderer.sendSync("get_config", '');
+	active_cfg = cfg.profile || 0;
+	const profileName = cfg.profileNames?.[active_cfg] || `Profile ${active_cfg + 1}`;
+	$("#toggle").html(profileName);
 	$("#wavelog_url").val(cfg.profiles[active_cfg].wavelog_url);
 	$("#wavelog_key").val(cfg.profiles[active_cfg].wavelog_key);
 	// $("#wavelog_id").val(cfg.wavelog_id);
@@ -538,4 +552,165 @@ function fillDropdown(data) {
 	} else {
 		select.val(data.length > 0 ? data[0].station_id : null);
 	}
+}
+
+// Dynamic Profile System Functions
+
+let selectedProfileIndex = null;
+
+function openProfileManager() {
+	selectedProfileIndex = cfg.profile || 0;
+	renderProfileList();
+	$('#profileModal').modal('show');
+}
+
+function renderProfileList() {
+	const listEl = $('#profileList');
+	listEl.empty();
+
+	cfg.profiles.forEach((profile, index) => {
+		const isActive = index === (cfg.profile || 0);
+		const name = cfg.profileNames?.[index] || `Profile ${index + 1}`;
+
+		const item = $(`
+			<div class="list-group-item" data-index="${index}">
+				<div class="d-flex align-items-center">
+					<input type="radio" name="profileSelect" value="${index}"
+						   ${index === selectedProfileIndex ? 'checked' : ''}>
+					<span class="ml-2 profile-name">${name}</span>
+					${isActive ? '<span class="badge badge-success ml-2">Active</span>' : ''}
+					<div class="ml-auto">
+						<button class="btn btn-sm btn-outline-secondary btn-rename">Rename</button>
+						<button class="btn btn-sm btn-outline-danger btn-delete"
+								${isActive || cfg.profiles.length <= 2 ? 'disabled' : ''}>
+							Delete
+						</button>
+					</div>
+				</div>
+			</div>
+		`);
+
+		listEl.append(item);
+	});
+}
+
+async function createProfile() {
+	const name = $('#newProfileName').val().trim();
+	if (!name) {
+		alert('Please enter a profile name');
+		return;
+	}
+
+	const result = ipcRenderer.sendSync('create_profile', name);
+	if (result.success) {
+		$('#newProfileName').val('');
+		await load_config();
+		renderProfileList();
+	}
+}
+
+async function deleteProfile(index) {
+	const name = cfg.profileNames?.[index] || `Profile ${index + 1}`;
+	if (!confirm(`Delete "${name}"?`)) return;
+
+	const result = ipcRenderer.sendSync('delete_profile', index);
+	if (result.success) {
+		if ((cfg.profile || 0) === index) {
+			active_cfg = 0;
+		}
+		await load_config();
+		renderProfileList();
+	} else {
+		alert(result.error);
+	}
+}
+
+async function renameProfile(index) {
+	const currentName = cfg.profileNames?.[index] || `Profile ${index + 1}`;
+
+	// Use a simple Bootstrap prompt via the modal
+	const newName = await showRenamePrompt(currentName);
+
+	if (newName && newName.trim() && newName !== currentName) {
+		ipcRenderer.sendSync('rename_profile', index, newName.trim());
+		await load_config();
+		renderProfileList();
+	}
+}
+
+function showRenamePrompt(currentName) {
+	return new Promise((resolve) => {
+		// Create a simple Bootstrap modal for input
+		const modalHtml = `
+			<div class="modal fade" id="renameModal" tabindex="-1">
+				<div class="modal-dialog">
+					<div class="modal-content">
+						<div class="modal-header">
+							<h5 class="modal-title">Rename Profile</h5>
+							<button type="button" class="close" data-dismiss="modal">
+								<span>&times;</span>
+							</button>
+						</div>
+						<div class="modal-body">
+							<input type="text" class="form-control" id="renameInput" value="${currentName}">
+						</div>
+						<div class="modal-footer">
+							<button type="button" class="btn btn-secondary" data-dismiss="modal" id="renameCancel">Cancel</button>
+							<button type="button" class="btn btn-primary" id="renameOk">OK</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		`;
+
+		// Remove any existing rename modal
+		$('#renameModal').remove();
+
+		// Add the new modal
+		$('body').append(modalHtml);
+
+		const $modal = $('#renameModal');
+		const $input = $('#renameInput');
+
+		// Handle OK button
+		$('#renameOk').click(() => {
+			$modal.modal('hide');
+			resolve($input.val());
+		});
+
+		// Handle Cancel button and X button
+		$('#renameCancel, #renameModal .close').click(() => {
+			$modal.modal('hide');
+			resolve(null);
+		});
+
+		// Handle Enter key
+		$input.keypress((e) => {
+			if (e.which === 13) {
+				$modal.modal('hide');
+				resolve($input.val());
+			}
+		});
+
+		// Handle modal hidden event
+		$modal.on('hidden.bs.modal', () => {
+			$('#renameModal').remove();
+		});
+
+		// Show the modal
+		$modal.modal('show');
+		$input.focus().select();
+	});
+}
+
+async function switchToSelectedProfile() {
+	if (selectedProfileIndex === null || selectedProfileIndex === (cfg.profile || 0)) {
+		$('#profileModal').modal('hide');
+		return;
+	}
+
+	ipcRenderer.sendSync('switch_profile', selectedProfileIndex);
+	active_cfg = selectedProfileIndex;
+	await load_config();
+	$('#profileModal').modal('hide');
 }

--- a/renderer.js
+++ b/renderer.js
@@ -148,11 +148,6 @@ $(document).ready(function() {
 		cleanup();
 	});
 
-	// Handle certificate installation prompt
-	ipcRenderer.on('prompt_cert_install', () => {
-		showCertInstallPrompt();
-	});
-
 	// Dropdown change handler
 	$('#radio_type').change(function() {
 		updateRadioFields();
@@ -486,86 +481,6 @@ function cleanup() {
 
 	// Clean up TCP connections
 	cleanupConnections();
-}
-
-function showCertInstallPrompt() {
-	const certInfo = ipcRenderer.sendSync('get_cert_info');
-
-	let message = `WaveLogGate has generated a self-signed SSL certificate for HTTPS support.\n\n`;
-	message += `To allow Safari/ browsers to connect to WaveLogGate via HTTPS without warnings, `;
-	message += `the certificate needs to be installed in your system's trust store.\n\n`;
-	message += `Certificate location:\n${certInfo.certPath}\n\n`;
-	message += `Would you like to install the certificate now?`;
-
-	// Use Bootstrap modal for better UI
-	const modalHtml = `
-<div class="modal fade" id="certInstallModal" tabindex="-1" role="dialog">
-	<div class="modal-dialog" role="document">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h5 class="modal-title">Install SSL Certificate</h5>
-			</div>
-			<div class="modal-body">
-				<p>WaveLogGate has generated a self-signed SSL certificate for HTTPS support.</p>
-				<p>To allow browsers (especially Safari) to connect to WaveLogGate via HTTPS without security warnings, the certificate needs to be installed in your system's trust store.</p>
-				<p><strong>Certificate location:</strong><br><code>${certInfo.certPath}</code></p>
-				<p>Would you like to install the certificate now?</p>
-			</div>
-			<div class="modal-footer">
-				<button type="button" class="btn btn-secondary" data-dismiss="modal">Later</button>
-				<button type="button" class="btn btn-primary" id="installCertBtn">Install Certificate</button>
-			</div>
-		</div>
-	</div>
-</div>`;
-
-	// Remove existing modal if present
-	$('#certInstallModal').remove();
-
-	// Add modal to body
-	$('body').append(modalHtml);
-
-	// Show modal
-	$('#certInstallModal').modal('show');
-
-	// Handle install button click
-	$('#installCertBtn').one('click', async () => {
-		$('#installCertBtn').prop('disabled', true).text('Installing...');
-
-		const result = ipcRenderer.sendSync('install_ca_cert');
-
-		$('#certInstallModal').modal('hide');
-
-		// Show result alert
-		if (result.success) {
-			showAlert('success', 'Certificate installed successfully! Safari and other browsers should now trust the WaveLogGate HTTPS connection.');
-		} else {
-			let alertMsg = '<strong>Automatic installation failed.</strong><br><br>';
-			alertMsg += result.message.replace(/\n/g, '<br>');
-			showAlert('warning', alertMsg);
-		}
-	});
-}
-
-function showAlert(type, message) {
-	const alertClass = type === 'success' ? 'alert-success' : type === 'warning' ? 'alert-warning' : 'alert-info';
-	const alertHtml = `
-<div class="alert ${alertClass} alert-dismissible fade show mt-2" role="alert">
-	${message}
-	<button type="button" class="close" data-dismiss="alert" aria-label="Close">
-		<span aria-hidden="true">&times;</span>
-	</button>
-</div>`;
-
-	// Add to the status tab's log div
-	$('#log').prepend(alertHtml);
-
-	// Auto-hide after 10 seconds for success messages
-	if (type === 'success') {
-		setTimeout(() => {
-			$('#log .alert').first().alert('close');
-		}, 10000);
-	}
 }
 
 function updateUtcTime() {


### PR DESCRIPTION
1.2 contains:
- Cert install and SSL-Handling for Safari on macOs (QSY/CAT works now with Gate and Safari, even if we still recommend Chrome/FF)
- Update-Check for New version
- New build-pipeline on github
- Profile-Manager for more than 2 profiles (downward-compatible)
- Auto-Quit old instances when (re-)launching the gate (no more cryptic JS-Errors)