### PR TITLE
Rotator

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -51,13 +51,37 @@ jobs:
         npm install -g appdmg@0.6.6
     - name: install dependencies
       run: npm install
+    - name: import signing certificate
+      env:
+        APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      run: |
+        if [ -n "$APPLE_CERTIFICATE" ]; then
+          echo "$APPLE_CERTIFICATE" | base64 --decode > certificate.p12
+          security create-keychain -p "" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+          security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+          rm certificate.p12
+          echo "APPLE_SIGN=true" >> $GITHUB_ENV
+          echo "Signing certificate imported"
+        else
+          echo "No signing certificate found, building unsigned"
+        fi
     - name: build and publish arm64
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: npx electron-forge publish --arch=arm64
     - name: build and publish x64
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: npx electron-forge publish --arch=x64
 
   build_on_win:

--- a/forge.config.js
+++ b/forge.config.js
@@ -27,6 +27,7 @@ function getRepoInfo() {
 }
 
 const repoInfo = getRepoInfo();
+const shouldSign = process.env.APPLE_SIGN === 'true';
 
 module.exports = {
 	packagerConfig: {
@@ -38,7 +39,21 @@ module.exports = {
 		productName: "WaveLogGate",
 		win32Metadata: {
 			companyName: "DJ7NT"
-		}
+		},
+		...(shouldSign ? {
+			osxSign: {
+				'hardened-runtime': true,
+				'gatekeeper-assess': false,
+				entitlements: 'entitlements.plist',
+				'entitlements-inherit': 'entitlements.plist',
+			},
+			osxNotarize: {
+				tool: 'notarytool',
+				appleId: process.env.APPLE_ID,
+				appleIdPassword: process.env.APPLE_ID_PASSWORD,
+				teamId: process.env.APPLE_TEAM_ID,
+			},
+		} : {}),
 	},
 	publishers: [
 		{

--- a/index.html
+++ b/index.html
@@ -198,6 +198,31 @@
 							<div id="log"></div>
 						</div>
 					</div>
+					<div id="rotator_panel" style="display: none; margin: 4px;">
+						<div style="border: 1px solid #727272; border-radius: 4px; padding: 6px 8px;">
+							<div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px;">
+								<strong style="font-size: 0.85em;">ROTATOR</strong>
+								<small id="rotator_status" style="color: #888;"></small>
+							</div>
+							<div id="rotator_current" style="font-size: 0.95em; min-height: 1.2em; margin-bottom: 4px; color: #c6c6c6;"></div>
+						<div style="display: flex; align-items: center; flex-wrap: wrap; gap: 6px; font-size: 0.85em;">
+								<div class="custom-control custom-radio custom-control-inline" style="margin-right: 0;">
+									<input type="radio" id="rot_off" name="rotator_follow" class="custom-control-input" value="off" checked>
+									<label class="custom-control-label" for="rot_off">Off</label>
+								</div>
+								<div class="custom-control custom-radio custom-control-inline" style="margin-right: 0;">
+									<input type="radio" id="rot_hf" name="rotator_follow" class="custom-control-input" value="hf">
+									<label class="custom-control-label" for="rot_hf">HF</label>
+								</div>
+								<span id="rotator_hf_az" style="color: #aaa; min-width: 55px;"></span>
+								<div class="custom-control custom-radio custom-control-inline" style="margin-right: 0;">
+									<input type="radio" id="rot_sat" name="rotator_follow" class="custom-control-input" value="sat">
+									<label class="custom-control-label" for="rot_sat">SAT</label>
+								</div>
+								<span id="rotator_sat_pos" style="color: #aaa;"></span>
+							</div>
+						</div>
+					</div>
 				</div>
 				<div class="tab-pane" id="config" role="tabpanel" aria-labelledby="config-tab">
 					<div class="row">
@@ -280,6 +305,20 @@
 							<div class="mb-1 col-mb-1">
 								<label for="ignore_pwr">Ignore Power</label>
 								<input type="checkbox" value="1" class="form-control form-control-sm" name="ignore_pwr" id="ignore_pwr" title="log out of wavelog to disregard old value" value="" />
+							</div>
+						</div>
+					</div>
+					<div class="row">
+						<div class="col">
+							<div class="mb-2 col-mb-2">
+								<label for="rotator_host">Rotator Host (rotctld)</label>
+								<input type="text" class="form-control form-control-sm" name="rotator_host" id="rotator_host" value="" placeholder="127.0.0.1" />
+							</div>
+						</div>
+						<div class="col">
+							<div class="mb-1 col-mb-1">
+								<label for="rotator_port">Rotator Port</label>
+								<input type="number" class="form-control form-control-sm" name="rotator_port" id="rotator_port" value="" placeholder="4533" />
 							</div>
 						</div>
 					</div>

--- a/index.html
+++ b/index.html
@@ -202,9 +202,17 @@
 						<div style="border: 1px solid #727272; border-radius: 4px; padding: 6px 8px;">
 							<div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px;">
 								<strong style="font-size: 0.85em;">ROTATOR</strong>
-								<small id="rotator_status" style="color: #888;"></small>
+								<div style="display: flex; align-items: center; gap: 8px;">
+									<small id="rotator_status" style="color: #888;"></small>
+									<button type="button" class="btn btn-sm btn-link p-0" id="rotatorSettings" title="Rotator Settings" style="color: #888;">
+										📡
+									</button>
+								</div>
 							</div>
 							<div id="rotator_current" style="font-size: 0.95em; min-height: 1.2em; margin-bottom: 4px; color: #c6c6c6;"></div>
+							<div id="rotator_hint" style="font-size: 0.85em; color: #888; margin-bottom: 4px; display: none;">
+								Click ⚙️ to configure rotator
+							</div>
 						<div style="display: flex; align-items: center; flex-wrap: wrap; gap: 6px; font-size: 0.85em;">
 								<div class="custom-control custom-radio custom-control-inline" style="margin-right: 0;">
 									<input type="radio" id="rot_off" name="rotator_follow" class="custom-control-input" value="off" checked>
@@ -220,6 +228,7 @@
 									<label class="custom-control-label" for="rot_sat">SAT</label>
 								</div>
 								<span id="rotator_sat_pos" style="color: #aaa;"></span>
+								<button type="button" class="btn btn-sm btn-secondary" id="rot_park" style="font-size: 0.85em; padding: 2px 8px; margin-left: 4px;">Park</button>
 							</div>
 						</div>
 					</div>
@@ -308,20 +317,6 @@
 							</div>
 						</div>
 					</div>
-					<div class="row">
-						<div class="col">
-							<div class="mb-2 col-mb-2">
-								<label for="rotator_host">Rotator Host (rotctld)</label>
-								<input type="text" class="form-control form-control-sm" name="rotator_host" id="rotator_host" value="" placeholder="127.0.0.1" />
-							</div>
-						</div>
-						<div class="col">
-							<div class="mb-1 col-mb-1">
-								<label for="rotator_port">Rotator Port</label>
-								<input type="number" class="form-control form-control-sm" name="rotator_port" id="rotator_port" value="" placeholder="4533" />
-							</div>
-						</div>
-					</div>
 					<div class="d-flex align-items-center justify-content-center" id="buttonsRow" style="gap: 12px;">
 						<button type="button" class="btn btn-primary" id="save" title="Save">💾</button>
 						<button type="button" class="btn btn-primary" id="toggle" title="Manage profiles">
@@ -371,6 +366,60 @@
 				<div class="modal-footer">
 					<button type="button" class="btn btn-secondary" data-dismiss="modal" id="advancedCancel">Cancel</button>
 					<button type="button" class="btn btn-primary" id="advancedSave">Save</button>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<!-- Rotator Settings Modal -->
+	<div class="modal fade" id="rotatorModal" tabindex="-1">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h5 class="modal-title">Rotator Settings</h5>
+					<button type="button" class="close" data-dismiss="modal">
+						<span>&times;</span>
+					</button>
+				</div>
+				<div class="modal-body">
+					<!-- Connection Settings -->
+					<h6>Connection (rotctld)</h6>
+					<div class="form-group">
+						<label for="modal_rotator_host">Rotator Host</label>
+						<input type="text" class="form-control" id="modal_rotator_host" placeholder="127.0.0.1">
+						<small class="form-text text-muted">Leave empty to disable rotator</small>
+					</div>
+					<div class="form-group">
+						<label for="modal_rotator_port">Rotator Port</label>
+						<input type="number" class="form-control" id="modal_rotator_port" min="1" max="65535" value="4533">
+					</div>
+
+					<!-- Threshold Settings -->
+					<h6 class="mt-3">Movement Threshold</h6>
+					<div class="form-group">
+						<label for="rotator_threshold_az">Azimuth Threshold (degrees)</label>
+						<input type="number" class="form-control" id="rotator_threshold_az" min="0" max="180" value="2">
+						<small class="form-text text-muted">Minimum movement before triggering rotator</small>
+					</div>
+					<div class="form-group">
+						<label for="rotator_threshold_el">Elevation Threshold (degrees)</label>
+						<input type="number" class="form-control" id="rotator_threshold_el" min="0" max="90" value="2">
+					</div>
+
+					<!-- Park Position Settings -->
+					<h6 class="mt-3">Park Position</h6>
+					<div class="form-group">
+						<label for="rotator_park_az">Park Azimuth (degrees)</label>
+						<input type="number" class="form-control" id="rotator_park_az" min="0" max="360" value="0">
+					</div>
+					<div class="form-group">
+						<label for="rotator_park_el">Park Elevation (degrees)</label>
+						<input type="number" class="form-control" id="rotator_park_el" min="0" max="90" value="0">
+					</div>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-secondary" data-dismiss="modal" id="rotatorCancel">Cancel</button>
+					<button type="button" class="btn btn-primary" id="rotatorSave">Save</button>
 				</div>
 			</div>
 		</div>

--- a/main.js
+++ b/main.js
@@ -394,9 +394,7 @@ ipcMain.on("rotator_set_follow", (event, mode) => {
 		rotatorStopping    = false;
 		rotatorStopAfterRPRT = null;
 		// Write S directly — bypasses queue, instant halt regardless of rotatorBusy
-		if (rotatorSocket && !rotatorSocket.destroyed) {
-			rotatorSocket.write('S\n');
-		}
+		rotatorSafeWrite('S\n');
 	} else {
 		// Connect now so the first P command goes out without a connection delay.
 		// Don't send p yet — some backends' p hangs until a P has been sent first.
@@ -424,7 +422,7 @@ ipcMain.handle("rotator_park", async (event, profile) => {
 	const sendParkCommands = (resolve) => {
 		const parkAz = profile.rotator_park_az || 0;
 		const parkEl = profile.rotator_park_el || 0;
-		rotatorSocket.write('S\n');
+		rotatorSafeWrite('S\n');
 		setTimeout(() => {
 			sendToRotator(parkAz, parkEl);
 			resolve({ success: true });
@@ -1869,6 +1867,27 @@ function rotatorClearBusy() {
 	rotatorBuffer     = '';
 }
 
+// Safe write to rotator socket with error handling
+// Closes socket and returns false on error, true on success
+function rotatorSafeWrite(command) {
+	if (!rotatorSocket || rotatorSocket.destroyed) {
+		return false;
+	}
+	try {
+		rotatorSocket.write(command, (err) => {
+			if (err) {
+				console.error('Rotator write error:', err.message);
+				closeRotatorSocket();
+			}
+		});
+		return true;
+	} catch (e) {
+		console.error('Rotator write exception:', e.message);
+		closeRotatorSocket();
+		return false;
+	}
+}
+
 function rotatorQueueProcess() {
 	if (rotatorBusy || !rotatorSocket || rotatorSocket.destroyed) {
 		return;
@@ -1923,7 +1942,7 @@ function rotatorQueueProcess() {
 			rotatorStopAfterRPRT = { az, el };
 			// Don't clear rotatorPendingSet yet — it becomes the P we send after S completes
 			rotatorSetBusy('set');  // Use 'set' type for S (same RPRT format)
-			rotatorSocket.write('S\n');
+			rotatorSafeWrite('S\n');
 			return;  // Will resume after S's RPRT arrives
 		}
 
@@ -1934,11 +1953,11 @@ function rotatorQueueProcess() {
 		rotatorLastCmdAz   = az;
 		rotatorLastCmdEl   = el;
 		rotatorSetBusy('set');
-		rotatorSocket.write(`P ${az} ${el}\n`);
+		rotatorSafeWrite(`P ${az} ${el}\n`);
 	} else if (rotatorPollPending) {
 		rotatorPollPending = false;
 		rotatorSetBusy('get');
-		rotatorSocket.write('p\n');
+		rotatorSafeWrite('p\n');
 	}
 }
 
@@ -1960,7 +1979,7 @@ function rotatorOnData(chunk) {
 				rotatorLastCmdAz      = az;
 				rotatorLastCmdEl      = el;
 				rotatorSetBusy('set');
-				rotatorSocket.write(`P ${az} ${el}\n`);
+				rotatorSafeWrite(`P ${az} ${el}\n`);
 				rotatorBuffer = '';  // Clear buffer after consuming S's RPRT
 				return;
 			}
@@ -2088,7 +2107,7 @@ function sendToRotator(az, el) {
 		rotatorLastCmdEl   = pEl;
 		rotatorClearBusy(); // abandon 'get' state (buffer cleared)
 		rotatorSetBusy('set');
-		rotatorSocket.write(`P ${pAz} ${pEl}\n`);
+		rotatorSafeWrite(`P ${pAz} ${pEl}\n`);
 		return;
 	}
 

--- a/main.js
+++ b/main.js
@@ -431,7 +431,7 @@ ipcMain.handle("rotator_park", async (event, profile) => {
 		if (rotatorConnecting) {
 			// Already connecting, wait for it
 			const checkInterval = setInterval(() => {
-				if (!rotatorConnecting && rotatorSocket && !rotatorSocket.destroyed) {
+				if (!rotatorConnecting && rotatorSocket && !rotatorSocket.destroyed && rotatorConnectedTo === target) {
 					clearInterval(checkInterval);
 					const parkAz = profile.rotator_park_az || 0;
 					const parkEl = profile.rotator_park_el || 0;
@@ -440,6 +440,10 @@ ipcMain.handle("rotator_park", async (event, profile) => {
 						sendToRotator(parkAz, parkEl);
 						resolve({ success: true });
 					}, 500);
+				} else if (!rotatorConnecting && !rotatorSocket) {
+					// Connection attempt failed
+					clearInterval(checkInterval);
+					resolve({ success: false, error: 'Connection failed' });
 				}
 			}, 100);
 			return;
@@ -471,11 +475,10 @@ ipcMain.handle("rotator_park", async (event, profile) => {
 		});
 
 		client.on('data', rotatorOnData);
+		client.setTimeout(3000, () => { if (rotatorConnecting) client.destroy(); });
 
 		client.on('error', (err) => {
-			rotatorConnecting = false;
-			rotatorSocket = null;
-			rotatorConnectedTo = null;
+			closeRotatorSocket();
 			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
 				s_mainWindow.webContents.send('rotator_update', { connected: false, error: err.message });
 			}
@@ -483,9 +486,19 @@ ipcMain.handle("rotator_park", async (event, profile) => {
 		});
 
 		client.on('close', () => {
-			rotatorSocket = null;
-			rotatorConnectedTo = null;
-			rotatorConnecting = false;
+			if (rotatorBusyTimer) { clearTimeout(rotatorBusyTimer); rotatorBusyTimer = null; }
+			if (rotatorSocket === client) { rotatorSocket = null; rotatorConnectedTo = null; }
+			rotatorConnecting    = false;
+			rotatorBusy          = false;
+			rotatorBuffer        = '';
+			rotatorCurrentCmd    = null;
+			rotatorHasSentP      = false;
+			rotatorLastCmdAz     = null;
+			rotatorLastCmdEl     = null;
+			rotatorCurrentAz     = null;
+			rotatorCurrentEl     = null;
+			rotatorStopping      = false;
+			rotatorStopAfterRPRT = null;
 			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
 				s_mainWindow.webContents.send('rotator_update', { connected: false });
 			}
@@ -1993,10 +2006,12 @@ function rotatorOnData(chunk) {
 		if (hasRPRT || nums.length >= 2) {
 			const az = nums[0];
 			const el = nums.length >= 2 ? nums[1] : 0;
-			rotatorCurrentAz = az;
-			rotatorCurrentEl = el;
+			if (nums.length >= 2) {
+				rotatorCurrentAz = az;
+				rotatorCurrentEl = el;
+			}
 			rotatorClearBusy();
-			if (az !== undefined && !isNaN(az) && s_mainWindow && !s_mainWindow.isDestroyed()) {
+			if (nums.length >= 2 && s_mainWindow && !s_mainWindow.isDestroyed()) {
 				s_mainWindow.webContents.send('rotator_position', { az, el });
 			}
 			rotatorQueueProcess();
@@ -2059,6 +2074,9 @@ function rotatorEnsureConnected() {
 		rotatorCurrentEl   = null;
 		rotatorStopping    = false;
 		rotatorStopAfterRPRT = null;
+		if (s_mainWindow && !s_mainWindow.isDestroyed()) {
+			s_mainWindow.webContents.send('rotator_update', { connected: false });
+		}
 	});
 }
 

--- a/main.js
+++ b/main.js
@@ -264,6 +264,11 @@ ipcMain.on("resize", async (event,arg) => {
 	event.returnValue=true;
 });
 
+ipcMain.on("get_window_size", async (event) => {
+	const size = s_mainWindow.getSize();
+	event.returnValue = { width: size[0], height: size[1] };
+});
+
 ipcMain.on("get_config", async (event, arg) => {
 	let storedcfg = storage.getSync('basic');
 	let realcfg={};
@@ -389,6 +394,105 @@ ipcMain.on("rotator_set_follow", (event, mode) => {
 	event.returnValue = true;
 });
 
+ipcMain.handle("rotator_park", async (event, profile) => {
+	// Ensure connection
+	const host = (profile.rotator_host || '').trim();
+	const port = parseInt(profile.rotator_port, 10);
+	if (!host || !port) {
+		return { success: false, error: 'Rotator not configured' };
+	}
+
+	// Ensure we're using the correct profile
+	const currentProfileIndex = defaultcfg.profile ?? 0;
+	defaultcfg.profiles[currentProfileIndex] = profile;
+
+	// Ensure connection and wait for it to be established
+	return new Promise((resolve) => {
+		const target = `${host}:${port}`;
+
+		// Check if already connected to the correct target
+		if (rotatorSocket && !rotatorSocket.destroyed && rotatorConnectedTo === target) {
+			// Already connected, send to park immediately
+			const parkAz = profile.rotator_park_az || 0;
+			const parkEl = profile.rotator_park_el || 0;
+
+			// Send stop command first
+			rotatorSocket.write('S\n');
+
+			// Then send to park position after a short delay
+			setTimeout(() => {
+				sendToRotator(parkAz, parkEl);
+				resolve({ success: true });
+			}, 500);
+			return;
+		}
+
+		// Need to establish connection
+		if (rotatorConnecting) {
+			// Already connecting, wait for it
+			const checkInterval = setInterval(() => {
+				if (!rotatorConnecting && rotatorSocket && !rotatorSocket.destroyed) {
+					clearInterval(checkInterval);
+					const parkAz = profile.rotator_park_az || 0;
+					const parkEl = profile.rotator_park_el || 0;
+					rotatorSocket.write('S\n');
+					setTimeout(() => {
+						sendToRotator(parkAz, parkEl);
+						resolve({ success: true });
+					}, 500);
+				}
+			}, 100);
+			return;
+		}
+
+		// Initiate connection
+		rotatorConnecting = true;
+		const client = net.createConnection({ host, port }, () => {
+			rotatorConnecting  = false;
+			rotatorSocket      = client;
+			rotatorConnectedTo = target;
+			client.setTimeout(0);
+
+			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
+				s_mainWindow.webContents.send('rotator_update', { connected: true });
+			}
+
+			const parkAz = profile.rotator_park_az || 0;
+			const parkEl = profile.rotator_park_el || 0;
+
+			// Send stop command first
+			client.write('S\n');
+
+			// Then send to park position after a short delay
+			setTimeout(() => {
+				sendToRotator(parkAz, parkEl);
+				resolve({ success: true });
+			}, 500);
+		});
+
+		client.on('data', rotatorOnData);
+
+		client.on('error', (err) => {
+			rotatorConnecting = false;
+			rotatorSocket = null;
+			rotatorConnectedTo = null;
+			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
+				s_mainWindow.webContents.send('rotator_update', { connected: false, error: err.message });
+			}
+			resolve({ success: false, error: err.message });
+		});
+
+		client.on('close', () => {
+			rotatorSocket = null;
+			rotatorConnectedTo = null;
+			rotatorConnecting = false;
+			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
+				s_mainWindow.webContents.send('rotator_update', { connected: false });
+			}
+		});
+	});
+});
+
 ipcMain.on("restart_udp", async (event) => {
 	// Restart UDP server with current configuration
 	startUdpServer();
@@ -424,6 +528,10 @@ ipcMain.on("create_profile", async (event, name) => {
 		ignore_pwr: false,
 		rotator_host: '',
 		rotator_port: '4533',
+		rotator_threshold_az: 2,
+		rotator_threshold_el: 2,
+		rotator_park_az: 0,
+		rotator_park_el: 0,
 	};
 
 	data.profiles.push(newProfile);
@@ -1780,16 +1888,21 @@ function rotatorQueueProcess() {
 	if (rotatorPendingSet) {
 		const { az, el } = rotatorPendingSet;
 
-		// Minimum movement threshold: only move if position differs by at least 1 degree
+		// Minimum movement threshold: only move if position differs by threshold
 		// Skip check if we don't have current position yet (first move always allowed)
 		if (rotatorCurrentAz !== null) {
+			// Get threshold from profile
+			const profile = defaultcfg.profiles[defaultcfg.profile ?? 0];
+			const thresholdAz = profile.rotator_threshold_az || 2;
+			const thresholdEl = profile.rotator_threshold_el || 2;
+
 			// Handle azimuth wraparound (359° → 1° = 2° difference, not 358°)
 			let azDiff = Math.abs(az - rotatorCurrentAz);
 			if (azDiff > 180) azDiff = 360 - azDiff;
 
 			const elDiff = el !== 0 ? Math.abs(el - (rotatorCurrentEl || 0)) : 0;
 			// For HF mode (el=0), only check azimuth. For SAT mode, check both.
-			if (azDiff < 1 && elDiff < 1) {
+			if (azDiff < thresholdAz && elDiff < thresholdEl) {
 				// Position too close, skip movement
 				rotatorPendingSet = null;
 				return;

--- a/main.js
+++ b/main.js
@@ -34,6 +34,34 @@ let wssHttpsServer; // HTTPS server for secure WebSocket
 let isShuttingDown = false;
 let activeConnections = new Set(); // Track active TCP connections
 let activeHttpRequests = new Set(); // Track active HTTP requests for cancellation
+let rotatorFollowMode = 'off'; // 'off', 'hf', 'sat' — runtime only, not persisted
+
+// Rotator state
+// Protocol (observed on real hardware):
+//   P az el\n  →  [current_az\ncurrent_el\n] × N  then  RPRT 0\n
+//   p\n        →  az\nel\n  (no RPRT)  — but HANGS with no response when idle on some backends
+//   S\n        →  RPRT 0\n  (halt — sent directly, bypasses queue)
+//
+// Important: some backends never respond to `p` until at least one `P` has been sent.
+// rotatorHasSentP gates the poll timer so we don't block the queue on connect.
+let rotatorSocket      = null;
+let rotatorConnecting  = false;
+let rotatorConnectedTo = null;
+let rotatorBusy        = false;   // waiting for a response
+let rotatorBusyTimer   = null;    // watchdog — clears stuck rotatorBusy after 5 s
+let rotatorBuffer      = '';      // accumulates incoming bytes
+let rotatorCurrentCmd  = null;    // 'set' | 'get'
+let rotatorPendingSet  = null;    // { az, el } — latest P not yet sent
+let rotatorPollPending = false;   // p query queued
+let rotatorPollTimer   = null;
+let rotatorHasSentP    = false;   // gate: don't poll until first P has been sent
+let rotatorLastPTime   = 0;       // ms timestamp of last P send — poll suppressed for 3 s after
+let rotatorLastCmdAz   = null;    // last commanded azimuth — for direction reversal detection
+let rotatorLastCmdEl   = null;    // last commanded elevation — for direction reversal detection
+let rotatorCurrentAz   = null;    // current real position from polls
+let rotatorCurrentEl   = null;    // current real position from polls
+let rotatorStopping    = false;   // true when we've sent S and are waiting for RPRT before sending P
+let rotatorStopAfterRPRT = null;  // { az, el } — P to send after S completes
 
 // Certificate paths for HTTPS server
 let certPaths = {
@@ -335,6 +363,32 @@ ipcMain.on("check_for_updates", async (event) => {
 	event.returnValue = true;
 });
 
+ipcMain.on("rotator_set_follow", (event, mode) => {
+	rotatorFollowMode = mode;
+	if (mode === 'off') {
+		rotatorPendingSet  = null;   // discard any queued move
+		rotatorPollPending = false;  // no more polls
+		rotatorLastCmdAz   = null;   // clear tracked position
+		rotatorLastCmdEl   = null;
+		rotatorCurrentAz   = null;
+		rotatorCurrentEl   = null;
+		rotatorStopping    = false;
+		rotatorStopAfterRPRT = null;
+		// Write S directly — bypasses queue, instant halt regardless of rotatorBusy
+		if (rotatorSocket && !rotatorSocket.destroyed) {
+			rotatorSocket.write('S\n');
+		}
+	} else {
+		// Connect now so the first P command goes out without a connection delay.
+		// Don't send p yet — some backends' p hangs until a P has been sent first.
+		const profile = defaultcfg.profiles[defaultcfg.profile ?? 0];
+		if ((profile.rotator_host || '').trim()) {
+			rotatorEnsureConnected();
+		}
+	}
+	event.returnValue = true;
+});
+
 ipcMain.on("restart_udp", async (event) => {
 	// Restart UDP server with current configuration
 	startUdpServer();
@@ -367,7 +421,9 @@ ipcMain.on("create_profile", async (event, name) => {
 		hamlib_host: '127.0.0.1',
 		hamlib_port: '4532',
 		hamlib_ena: false,
-		ignore_pwr: false
+		ignore_pwr: false,
+		rotator_host: '',
+		rotator_port: '4533',
 	};
 
 	data.profiles.push(newProfile);
@@ -473,6 +529,10 @@ function shutdownApplication() {
             console.log('Sending cleanup signal to renderer...');
             s_mainWindow.webContents.send('cleanup');
         }
+
+        // Clean up rotator poll and socket
+        if (rotatorPollTimer) { clearInterval(rotatorPollTimer); rotatorPollTimer = null; }
+        closeRotatorSocket();
 
         // Clean up TCP connections
         cleanupConnections();
@@ -1471,6 +1531,10 @@ function startserver() {
 
 		// Start Secure WebSocket server
 		startSecureWebSocketServer();
+
+		// Start rotator position polling (every 2 s; no-ops when no rotator configured)
+		startRotatorPoll();
+
 	} catch(e) {
 		console.error('Error in startserver:', e);
 		tomsg('Some other Tool blocks Port 2333/54321/54322. Stop it, and restart this');
@@ -1510,6 +1574,8 @@ function startWebSocketServer() {
 				console.error('WebSocket unexpected response:', res.statusCode);
 				cleanupClient();
 			});
+
+			ws.on('message', handleWsIncomingMessage);
 
 			// Send current radio status on connection
 			try {
@@ -1606,6 +1672,8 @@ function startSecureWebSocketServer() {
 					cleanupClient();
 				});
 
+				ws.on('message', handleWsIncomingMessage);
+
 				// Send current radio status on connection
 				try {
 					ws.send(JSON.stringify({
@@ -1649,6 +1717,300 @@ function startSecureWebSocketServer() {
 			wssHttpsServer = null;
 		}
 		wssServer = null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rotator command queue.
+// One persistent TCP connection; commands serialised so responses don't mix.
+// P az el\n  →  RPRT 0\n          (position command, RPRT arrives fast)
+// p\n        →  az\nel\n           (poll position, NO RPRT on some backends)
+// S\n        →  RPRT 0\n          (stop/halt command)
+//
+// Direction changes: When new target differs from last commanded target,
+// S is sent first, then P after S's RPRT arrives (stop-before-move pattern).
+// ---------------------------------------------------------------------------
+
+function closeRotatorSocket() {
+	if (rotatorBusyTimer) { clearTimeout(rotatorBusyTimer); rotatorBusyTimer = null; }
+	if (rotatorSocket) { rotatorSocket.destroy(); rotatorSocket = null; }
+	rotatorConnecting  = false;
+	rotatorConnectedTo = null;
+	rotatorBusy        = false;
+	rotatorBuffer      = '';
+	rotatorCurrentCmd  = null;
+	rotatorHasSentP    = false;
+	rotatorLastCmdAz   = null;
+	rotatorLastCmdEl   = null;
+	rotatorCurrentAz   = null;
+	rotatorCurrentEl   = null;
+	rotatorStopping    = false;
+	rotatorStopAfterRPRT = null;
+	if (s_mainWindow && !s_mainWindow.isDestroyed()) {
+		s_mainWindow.webContents.send('rotator_update', { connected: false });
+	}
+}
+
+// Set busy state and arm 5-second watchdog to prevent permanent stuck state.
+function rotatorSetBusy(cmd) {
+	rotatorBusy       = true;
+	rotatorCurrentCmd = cmd;
+	if (rotatorBusyTimer) clearTimeout(rotatorBusyTimer);
+	rotatorBusyTimer = setTimeout(() => {
+		rotatorBusy       = false;
+		rotatorCurrentCmd = null;
+		rotatorBuffer     = '';
+		rotatorBusyTimer  = null;
+		rotatorQueueProcess();
+	}, 5000);
+}
+
+function rotatorClearBusy() {
+	if (rotatorBusyTimer) { clearTimeout(rotatorBusyTimer); rotatorBusyTimer = null; }
+	rotatorBusy       = false;
+	rotatorCurrentCmd = null;
+	rotatorBuffer     = '';
+}
+
+function rotatorQueueProcess() {
+	if (rotatorBusy || !rotatorSocket || rotatorSocket.destroyed) {
+		return;
+	}
+
+	if (rotatorPendingSet) {
+		const { az, el } = rotatorPendingSet;
+
+		// Minimum movement threshold: only move if position differs by at least 1 degree
+		// Skip check if we don't have current position yet (first move always allowed)
+		if (rotatorCurrentAz !== null) {
+			// Handle azimuth wraparound (359° → 1° = 2° difference, not 358°)
+			let azDiff = Math.abs(az - rotatorCurrentAz);
+			if (azDiff > 180) azDiff = 360 - azDiff;
+
+			const elDiff = el !== 0 ? Math.abs(el - (rotatorCurrentEl || 0)) : 0;
+			// For HF mode (el=0), only check azimuth. For SAT mode, check both.
+			if (azDiff < 1 && elDiff < 1) {
+				// Position too close, skip movement
+				rotatorPendingSet = null;
+				return;
+			}
+		}
+
+		// Direction reversal detection based on actual current position
+		// Only send S if we're currently moving in the opposite direction
+		let needStop = false;
+		if (rotatorCurrentAz !== null && rotatorLastCmdAz !== null && !rotatorStopping) {
+			// Calculate direction from current position to last commanded target
+			let lastDir = rotatorLastCmdAz - rotatorCurrentAz;
+			if (lastDir > 180) lastDir -= 360;
+			if (lastDir < -180) lastDir += 360;
+
+			// Calculate direction from current position to new target
+			let newDir = az - rotatorCurrentAz;
+			if (newDir > 180) newDir -= 360;
+			if (newDir < -180) newDir += 360;
+
+			// If directions have opposite signs, we need to stop first
+			needStop = (lastDir * newDir < 0);
+		}
+
+		if (needStop) {
+			// Send S first, then P after RPRT
+			rotatorStopping    = true;
+			rotatorStopAfterRPRT = { az, el };
+			// Don't clear rotatorPendingSet yet — it becomes the P we send after S completes
+			rotatorSetBusy('set');  // Use 'set' type for S (same RPRT format)
+			rotatorSocket.write('S\n');
+			return;  // Will resume after S's RPRT arrives
+		}
+
+		// No stop needed — send P directly
+		rotatorPendingSet  = null;
+		rotatorHasSentP    = true;
+		rotatorLastPTime   = Date.now();
+		rotatorLastCmdAz   = az;
+		rotatorLastCmdEl   = el;
+		rotatorSetBusy('set');
+		rotatorSocket.write(`P ${az} ${el}\n`);
+	} else if (rotatorPollPending) {
+		rotatorPollPending = false;
+		rotatorSetBusy('get');
+		rotatorSocket.write('p\n');
+	}
+}
+
+function rotatorOnData(chunk) {
+	const raw = chunk.toString();
+	rotatorBuffer += raw;
+
+	if (rotatorCurrentCmd === 'set') {
+		// P response ends with RPRT N\n
+		if (/RPRT\s+-?\d+/.test(rotatorBuffer)) {
+			// If we just sent S to stop before a direction change, now send the P
+			if (rotatorStopping && rotatorStopAfterRPRT) {
+				const { az, el } = rotatorStopAfterRPRT;
+				rotatorStopping       = false;
+				rotatorStopAfterRPRT  = null;
+				rotatorPendingSet     = null;  // Clear the pending set since we're about to send it
+				rotatorHasSentP       = true;
+				rotatorLastPTime      = Date.now();
+				rotatorLastCmdAz      = az;
+				rotatorLastCmdEl      = el;
+				rotatorSetBusy('set');
+				rotatorSocket.write(`P ${az} ${el}\n`);
+				rotatorBuffer = '';  // Clear buffer after consuming S's RPRT
+				return;
+			}
+
+			// Suppress any queued poll — let the rotator start moving uninterrupted.
+			// The next poll timer cycle (≤2 s) will pick it up naturally.
+			rotatorPollPending = false;
+			rotatorClearBusy();
+			rotatorQueueProcess();
+		}
+	} else if (rotatorCurrentCmd === 'get') {
+		// p response: az\nel\n (no RPRT on some backends) or az\nel\nRPRT 0\n (standard).
+		// Consider complete when RPRT is present OR when ≥2 numeric lines found.
+		const hasRPRT = /RPRT\s+-?\d+/.test(rotatorBuffer);
+		const nums = rotatorBuffer.split('\n')
+			.map(l => l.trim())
+			.filter(l => l !== '' && !/^RPRT/.test(l))
+			.map(l => parseFloat(l))
+			.filter(n => !isNaN(n));
+		if (hasRPRT || nums.length >= 2) {
+			const az = nums[0];
+			const el = nums.length >= 2 ? nums[1] : 0;
+			rotatorCurrentAz = az;
+			rotatorCurrentEl = el;
+			rotatorClearBusy();
+			if (az !== undefined && !isNaN(az) && s_mainWindow && !s_mainWindow.isDestroyed()) {
+				s_mainWindow.webContents.send('rotator_position', { az, el });
+			}
+			rotatorQueueProcess();
+		}
+	} else {
+		// No command in flight — discard unexpected data (e.g. RPRT from a direct S\n write)
+		rotatorBuffer = '';
+	}
+}
+
+function rotatorEnsureConnected() {
+	const profile = defaultcfg.profiles[defaultcfg.profile ?? 0];
+	const host = (profile.rotator_host || '').trim();
+	const port = parseInt(profile.rotator_port, 10);
+	if (!host || !port) return;
+
+	const target = `${host}:${port}`;
+	if (rotatorSocket && rotatorConnectedTo !== target) closeRotatorSocket();
+
+	if (rotatorSocket && !rotatorSocket.destroyed) {
+		rotatorQueueProcess();
+		return;
+	}
+
+	if (rotatorConnecting) return;
+	rotatorConnecting = true;
+
+	const client = net.createConnection({ host, port }, () => {
+		rotatorConnecting  = false;
+		rotatorSocket      = client;
+		rotatorConnectedTo = target;
+		client.setTimeout(0);
+		if (s_mainWindow && !s_mainWindow.isDestroyed()) {
+			s_mainWindow.webContents.send('rotator_update', { connected: true });
+		}
+		rotatorQueueProcess();
+	});
+
+	client.on('data', rotatorOnData);
+	client.setTimeout(3000, () => { if (rotatorConnecting) client.destroy(); });
+
+	client.on('error', (err) => {
+		closeRotatorSocket();
+		if (s_mainWindow && !s_mainWindow.isDestroyed()) {
+			s_mainWindow.webContents.send('rotator_update', { connected: false });
+		}
+	});
+
+	client.on('close', () => {
+		if (rotatorBusyTimer) { clearTimeout(rotatorBusyTimer); rotatorBusyTimer = null; }
+		if (rotatorSocket === client) { rotatorSocket = null; rotatorConnectedTo = null; }
+		rotatorConnecting  = false;
+		rotatorBusy        = false;
+		rotatorBuffer      = '';
+		rotatorCurrentCmd  = null;
+		rotatorHasSentP    = false;
+		rotatorLastCmdAz   = null;
+		rotatorLastCmdEl   = null;
+		rotatorCurrentAz   = null;
+		rotatorCurrentEl   = null;
+		rotatorStopping    = false;
+		rotatorStopAfterRPRT = null;
+	});
+}
+
+function sendToRotator(az, el) {
+	rotatorPendingSet = { az, el }; // overwrite — only latest target matters
+	rotatorPollPending = false;     // cancel any queued poll — movement takes priority
+
+	// Pre-empt an in-flight p poll: write P immediately rather than waiting for the
+	// p response. The pending p response (az/el/RPRT) arriving afterwards will be
+	// handled by the 'set' branch (RPRT satisfies the detector; numeric lines drain).
+	if (rotatorSocket && !rotatorSocket.destroyed && rotatorCurrentCmd === 'get') {
+		const { az: pAz, el: pEl } = rotatorPendingSet;
+		rotatorPendingSet  = null;
+		rotatorHasSentP    = true;
+		rotatorLastPTime   = Date.now();
+		rotatorLastCmdAz   = pAz;
+		rotatorLastCmdEl   = pEl;
+		rotatorClearBusy(); // abandon 'get' state (buffer cleared)
+		rotatorSetBusy('set');
+		rotatorSocket.write(`P ${pAz} ${pEl}\n`);
+		return;
+	}
+
+	rotatorEnsureConnected();
+}
+
+function startRotatorPoll() {
+	if (rotatorPollTimer) return;
+	rotatorPollTimer = setInterval(() => {
+		if (rotatorFollowMode === 'off') return;
+		if (!rotatorHasSentP) return;
+		const msSinceP = Date.now() - rotatorLastPTime;
+		if (msSinceP < 3000) return;
+		const profile = defaultcfg.profiles[defaultcfg.profile ?? 0];
+		if (!(profile.rotator_host || '').trim()) return;
+		if (!rotatorPollPending) {
+			rotatorPollPending = true;
+			rotatorEnsureConnected();
+		}
+	}, 2000);
+}
+
+function handleWsIncomingMessage(data) {
+	try {
+		const msg = JSON.parse(data.toString());
+		if (msg.type === 'lookup_result' && msg.payload && msg.payload.azimuth !== undefined) {
+			const az = msg.payload.azimuth;
+			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
+				s_mainWindow.webContents.send('rotator_bearing', { type: 'hf', az });
+			}
+			if (rotatorFollowMode === 'hf') {
+				sendToRotator(az, 0);
+			}
+		} else if (msg.type === 'satellite_position' && msg.data) {
+			const az = parseFloat(msg.data.azimuth);
+			const el = parseFloat(msg.data.elevation);
+			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
+				s_mainWindow.webContents.send('rotator_bearing', { type: 'sat', az, el });
+			}
+			if (rotatorFollowMode === 'sat') {
+				sendToRotator(az, el);
+			}
+		}
+	} catch (e) {
+		// Not JSON or unknown message type, ignore
 	}
 }
 

--- a/main.js
+++ b/main.js
@@ -63,6 +63,20 @@ let rotatorCurrentEl   = null;    // current real position from polls
 let rotatorStopping    = false;   // true when we've sent S and are waiting for RPRT before sending P
 let rotatorStopAfterRPRT = null;  // { az, el } — P to send after S completes
 
+// Rotator timing constants (milliseconds)
+const ROTATOR_BUSY_WATCHDOG_MS = 5000;     // watchdog: clears stuck rotatorBusy
+const ROTATOR_POLL_INTERVAL_MS = 2000;     // position poll interval
+const ROTATOR_POLL_SUPPRESSION_MS = 3000;  // suppress polls for this long after P command
+const ROTATOR_CONNECTION_TIMEOUT_MS = 3000;// socket connection timeout
+const ROTATOR_PARK_COMMAND_DELAY_MS = 500; // delay between S and P in park sequence
+const ROTATOR_PARK_WAIT_TIMEOUT_MS = 10000;// timeout waiting for connection in park
+const ROTATOR_WS_RATE_LIMIT_MS = 150;      // minimum time between WebSocket-triggered commands
+
+// Rate limiting state for WebSocket commands
+let rotatorLastWsCommandTime = 0;
+let rotatorPendingWsCommand = null;        // { az, el, type } — pending rate-limited command
+let rotatorWsRateLimitTimer = null;        // timer for sending pending command
+
 // Certificate paths for HTTPS server
 let certPaths = {
 	key: null,
@@ -414,7 +428,7 @@ ipcMain.handle("rotator_park", async (event, profile) => {
 		setTimeout(() => {
 			sendToRotator(parkAz, parkEl);
 			resolve({ success: true });
-		}, 500);
+		}, ROTATOR_PARK_COMMAND_DELAY_MS);
 	};
 
 	// Ensure connection and wait for it to be established
@@ -447,7 +461,7 @@ ipcMain.handle("rotator_park", async (event, profile) => {
 					cleanup();
 					resolve({ success: false, error: 'Connection timeout' });
 				}
-			}, 10000); // 10 second timeout for connection waiting
+			}, ROTATOR_PARK_WAIT_TIMEOUT_MS);
 
 			const cleanup = () => {
 				if (resolved) return;
@@ -614,6 +628,7 @@ function shutdownApplication() {
 
         // Clean up rotator poll and socket
         if (rotatorPollTimer) { clearInterval(rotatorPollTimer); rotatorPollTimer = null; }
+        if (rotatorWsRateLimitTimer) { clearTimeout(rotatorWsRateLimitTimer); rotatorWsRateLimitTimer = null; }
         closeRotatorSocket();
 
         // Clean up TCP connections
@@ -1833,7 +1848,7 @@ function closeRotatorSocket() {
 	}
 }
 
-// Set busy state and arm 5-second watchdog to prevent permanent stuck state.
+// Set busy state and arm watchdog to prevent permanent stuck state.
 function rotatorSetBusy(cmd) {
 	rotatorBusy       = true;
 	rotatorCurrentCmd = cmd;
@@ -1844,7 +1859,7 @@ function rotatorSetBusy(cmd) {
 		rotatorBuffer     = '';
 		rotatorBusyTimer  = null;
 		rotatorQueueProcess();
-	}, 5000);
+	}, ROTATOR_BUSY_WATCHDOG_MS);
 }
 
 function rotatorClearBusy() {
@@ -1874,8 +1889,9 @@ function rotatorQueueProcess() {
 			let azDiff = Math.abs(az - rotatorCurrentAz);
 			if (azDiff > 180) azDiff = 360 - azDiff;
 
-			const elDiff = el !== 0 ? Math.abs(el - (rotatorCurrentEl || 0)) : 0;
-			// For HF mode (el=0), only check azimuth. For SAT mode, check both.
+			// Elevation difference - always calculate, don't skip for el=0
+			// This allows proper threshold checking when park elevation is 0°
+			const elDiff = Math.abs(el - (rotatorCurrentEl || 0));
 			if (azDiff < thresholdAz && elDiff < thresholdEl) {
 				// Position too close, skip movement
 				rotatorPendingSet = null;
@@ -2004,7 +2020,7 @@ function rotatorCreateConnection(host, port, callbacks = {}) {
 	});
 
 	client.on('data', rotatorOnData);
-	client.setTimeout(3000, () => { if (rotatorConnecting) client.destroy(); });
+	client.setTimeout(ROTATOR_CONNECTION_TIMEOUT_MS, () => { if (rotatorConnecting) client.destroy(); });
 
 	client.on('error', (err) => {
 		closeRotatorSocket();
@@ -2085,39 +2101,87 @@ function startRotatorPoll() {
 		if (rotatorFollowMode === 'off') return;
 		if (!rotatorHasSentP) return;
 		const msSinceP = Date.now() - rotatorLastPTime;
-		if (msSinceP < 3000) return;
+		if (msSinceP < ROTATOR_POLL_SUPPRESSION_MS) return;
 		const profile = defaultcfg.profiles[defaultcfg.profile ?? 0];
 		if (!(profile.rotator_host || '').trim()) return;
 		if (!rotatorPollPending) {
 			rotatorPollPending = true;
 			rotatorEnsureConnected();
 		}
-	}, 2000);
+	}, ROTATOR_POLL_INTERVAL_MS);
+}
+
+// Send rotator command with rate limiting to prevent overwhelming rotctld
+function sendRateLimitedRotatorCommand(az, el, type) {
+	const now = Date.now();
+	const timeSinceLastCommand = now - rotatorLastWsCommandTime;
+
+	// Store the latest command (overwrites any previous pending command)
+	rotatorPendingWsCommand = { az, el, type };
+
+	// If enough time has passed, send immediately
+	if (timeSinceLastCommand >= ROTATOR_WS_RATE_LIMIT_MS) {
+		// Clear any existing rate limit timer
+		if (rotatorWsRateLimitTimer) {
+			clearTimeout(rotatorWsRateLimitTimer);
+			rotatorWsRateLimitTimer = null;
+		}
+
+		// Send the command
+		rotatorLastWsCommandTime = now;
+		const cmd = rotatorPendingWsCommand;
+		rotatorPendingWsCommand = null;
+		sendToRotator(cmd.az, cmd.el);
+	} else if (!rotatorWsRateLimitTimer) {
+		// Not enough time has passed and no timer is set, create one
+		const delay = ROTATOR_WS_RATE_LIMIT_MS - timeSinceLastCommand;
+		rotatorWsRateLimitTimer = setTimeout(() => {
+			if (rotatorPendingWsCommand) {
+				rotatorLastWsCommandTime = Date.now();
+				const cmd = rotatorPendingWsCommand;
+				rotatorPendingWsCommand = null;
+				sendToRotator(cmd.az, cmd.el);
+			}
+			rotatorWsRateLimitTimer = null;
+		}, delay);
+	}
+	// If timer already exists, the new command is already stored in rotatorPendingWsCommand
+	// and will be sent when the timer fires
 }
 
 function handleWsIncomingMessage(data) {
 	try {
 		const msg = JSON.parse(data.toString());
+
 		if (msg.type === 'lookup_result' && msg.payload && msg.payload.azimuth !== undefined) {
-			const az = msg.payload.azimuth;
+			const az = parseFloat(msg.payload.azimuth);
+			// Validate azimuth
+			if (typeof az !== 'number' || isNaN(az) || az < 0 || az > 360) {
+				return; // Invalid azimuth, ignore message
+			}
+
 			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
 				s_mainWindow.webContents.send('rotator_bearing', { type: 'hf', az });
 			}
 			if (rotatorFollowMode === 'hf') {
-				sendToRotator(az, 0);
+				sendRateLimitedRotatorCommand(az, 0, 'hf');
 			}
 		} else if (msg.type === 'satellite_position' && msg.data) {
 			const az = parseFloat(msg.data.azimuth);
 			const el = parseFloat(msg.data.elevation);
+			// Validate azimuth and elevation
+			if (typeof az !== 'number' || isNaN(az) || az < 0 || az > 360) return;
+			if (typeof el !== 'number' || isNaN(el) || el < 0 || el > 90) return;
+
 			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
 				s_mainWindow.webContents.send('rotator_bearing', { type: 'sat', az, el });
 			}
 			if (rotatorFollowMode === 'sat') {
-				sendToRotator(az, el);
+				sendRateLimitedRotatorCommand(az, el, 'sat');
 			}
 		}
 	} catch (e) {
-		// Not JSON or unknown message type, ignore
+		// Not JSON or unknown message type, ignore silently
 	}
 }
 

--- a/main.js
+++ b/main.js
@@ -406,102 +406,63 @@ ipcMain.handle("rotator_park", async (event, profile) => {
 	const currentProfileIndex = defaultcfg.profile ?? 0;
 	defaultcfg.profiles[currentProfileIndex] = profile;
 
+	// Helper: send park commands to rotator
+	const sendParkCommands = (resolve) => {
+		const parkAz = profile.rotator_park_az || 0;
+		const parkEl = profile.rotator_park_el || 0;
+		rotatorSocket.write('S\n');
+		setTimeout(() => {
+			sendToRotator(parkAz, parkEl);
+			resolve({ success: true });
+		}, 500);
+	};
+
 	// Ensure connection and wait for it to be established
 	return new Promise((resolve) => {
 		const target = `${host}:${port}`;
 
 		// Check if already connected to the correct target
 		if (rotatorSocket && !rotatorSocket.destroyed && rotatorConnectedTo === target) {
-			// Already connected, send to park immediately
-			const parkAz = profile.rotator_park_az || 0;
-			const parkEl = profile.rotator_park_el || 0;
-
-			// Send stop command first
-			rotatorSocket.write('S\n');
-
-			// Then send to park position after a short delay
-			setTimeout(() => {
-				sendToRotator(parkAz, parkEl);
-				resolve({ success: true });
-			}, 500);
+			sendParkCommands(resolve);
 			return;
 		}
 
 		// Need to establish connection
 		if (rotatorConnecting) {
-			// Already connecting, wait for it
+			// Already connecting, wait for it with timeout fallback
+			let resolved = false;
 			const checkInterval = setInterval(() => {
 				if (!rotatorConnecting && rotatorSocket && !rotatorSocket.destroyed && rotatorConnectedTo === target) {
-					clearInterval(checkInterval);
-					const parkAz = profile.rotator_park_az || 0;
-					const parkEl = profile.rotator_park_el || 0;
-					rotatorSocket.write('S\n');
-					setTimeout(() => {
-						sendToRotator(parkAz, parkEl);
-						resolve({ success: true });
-					}, 500);
+					cleanup();
+					sendParkCommands(resolve);
 				} else if (!rotatorConnecting && !rotatorSocket) {
-					// Connection attempt failed
-					clearInterval(checkInterval);
+					cleanup();
 					resolve({ success: false, error: 'Connection failed' });
 				}
 			}, 100);
+
+			// Timeout fallback: prevent infinite polling
+			const timeoutId = setTimeout(() => {
+				if (!resolved) {
+					cleanup();
+					resolve({ success: false, error: 'Connection timeout' });
+				}
+			}, 10000); // 10 second timeout for connection waiting
+
+			const cleanup = () => {
+				if (resolved) return;
+				resolved = true;
+				clearInterval(checkInterval);
+				clearTimeout(timeoutId);
+			};
 			return;
 		}
 
-		// Initiate connection
-		rotatorConnecting = true;
-		const client = net.createConnection({ host, port }, () => {
-			rotatorConnecting  = false;
-			rotatorSocket      = client;
-			rotatorConnectedTo = target;
-			client.setTimeout(0);
-
-			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
-				s_mainWindow.webContents.send('rotator_update', { connected: true });
-			}
-
-			const parkAz = profile.rotator_park_az || 0;
-			const parkEl = profile.rotator_park_el || 0;
-
-			// Send stop command first
-			client.write('S\n');
-
-			// Then send to park position after a short delay
-			setTimeout(() => {
-				sendToRotator(parkAz, parkEl);
-				resolve({ success: true });
-			}, 500);
-		});
-
-		client.on('data', rotatorOnData);
-		client.setTimeout(3000, () => { if (rotatorConnecting) client.destroy(); });
-
-		client.on('error', (err) => {
-			closeRotatorSocket();
-			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
-				s_mainWindow.webContents.send('rotator_update', { connected: false, error: err.message });
-			}
-			resolve({ success: false, error: err.message });
-		});
-
-		client.on('close', () => {
-			if (rotatorBusyTimer) { clearTimeout(rotatorBusyTimer); rotatorBusyTimer = null; }
-			if (rotatorSocket === client) { rotatorSocket = null; rotatorConnectedTo = null; }
-			rotatorConnecting    = false;
-			rotatorBusy          = false;
-			rotatorBuffer        = '';
-			rotatorCurrentCmd    = null;
-			rotatorHasSentP      = false;
-			rotatorLastCmdAz     = null;
-			rotatorLastCmdEl     = null;
-			rotatorCurrentAz     = null;
-			rotatorCurrentEl     = null;
-			rotatorStopping      = false;
-			rotatorStopAfterRPRT = null;
-			if (s_mainWindow && !s_mainWindow.isDestroyed()) {
-				s_mainWindow.webContents.send('rotator_update', { connected: false });
-			}
+		// Initiate connection using shared handler
+		rotatorCreateConnection(host, port, {
+			onConnect: (client) => sendParkCommands(resolve),
+			onError: (err) => resolve({ success: false, error: err.message }),
+			onClose: () => resolve({ success: false, error: 'Connection closed' })
 		});
 	});
 });
@@ -2022,21 +1983,13 @@ function rotatorOnData(chunk) {
 	}
 }
 
-function rotatorEnsureConnected() {
-	const profile = defaultcfg.profiles[defaultcfg.profile ?? 0];
-	const host = (profile.rotator_host || '').trim();
-	const port = parseInt(profile.rotator_port, 10);
-	if (!host || !port) return;
-
+// Shared rotator socket connection handler
+// Creates and configures a rotctld TCP connection with standard event handlers
+function rotatorCreateConnection(host, port, callbacks = {}) {
 	const target = `${host}:${port}`;
-	if (rotatorSocket && rotatorConnectedTo !== target) closeRotatorSocket();
+	const { onConnect, onError, onClose } = callbacks;
 
-	if (rotatorSocket && !rotatorSocket.destroyed) {
-		rotatorQueueProcess();
-		return;
-	}
-
-	if (rotatorConnecting) return;
+	if (rotatorConnecting) return null;
 	rotatorConnecting = true;
 
 	const client = net.createConnection({ host, port }, () => {
@@ -2047,7 +2000,7 @@ function rotatorEnsureConnected() {
 		if (s_mainWindow && !s_mainWindow.isDestroyed()) {
 			s_mainWindow.webContents.send('rotator_update', { connected: true });
 		}
-		rotatorQueueProcess();
+		if (onConnect) onConnect(client);
 	});
 
 	client.on('data', rotatorOnData);
@@ -2056,8 +2009,9 @@ function rotatorEnsureConnected() {
 	client.on('error', (err) => {
 		closeRotatorSocket();
 		if (s_mainWindow && !s_mainWindow.isDestroyed()) {
-			s_mainWindow.webContents.send('rotator_update', { connected: false });
+			s_mainWindow.webContents.send('rotator_update', { connected: false, error: err.message });
 		}
+		if (onError) onError(err);
 	});
 
 	client.on('close', () => {
@@ -2077,6 +2031,28 @@ function rotatorEnsureConnected() {
 		if (s_mainWindow && !s_mainWindow.isDestroyed()) {
 			s_mainWindow.webContents.send('rotator_update', { connected: false });
 		}
+		if (onClose) onClose();
+	});
+
+	return client;
+}
+
+function rotatorEnsureConnected() {
+	const profile = defaultcfg.profiles[defaultcfg.profile ?? 0];
+	const host = (profile.rotator_host || '').trim();
+	const port = parseInt(profile.rotator_port, 10);
+	if (!host || !port) return;
+
+	const target = `${host}:${port}`;
+	if (rotatorSocket && rotatorConnectedTo !== target) closeRotatorSocket();
+
+	if (rotatorSocket && !rotatorSocket.destroyed) {
+		rotatorQueueProcess();
+		return;
+	}
+
+	rotatorCreateConnection(host, port, {
+		onConnect: () => rotatorQueueProcess()
 	});
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gateway for connecting WSJT-* and FLRig to Wavelog",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "DJ7NT",
   "scripts": {
     "start": "electron-forge start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gateway for connecting WSJT-* and FLRig to Wavelog",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.2.2",
+  "version": "1.2.1",
   "author": "DJ7NT",
   "scripts": {
     "start": "electron-forge start",

--- a/renderer.js
+++ b/renderer.js
@@ -27,6 +27,12 @@ const input_url=select("#wavelog_url");
 let oldCat={ vfo: 0, mode: "SSB" };
 let lastCat=0;
 
+// Window size constants
+const WINDOW_WIDTH = 430;
+const TAB_HEIGHT_CONFIG = 500;
+const TAB_HEIGHT_STATUS = 320;
+const MODAL_HEIGHT = 600;
+
 $(document).ready(function() {
 
 	load_config();
@@ -68,9 +74,6 @@ $(document).ready(function() {
 				// All radio settings already disabled
 				break;
 		}
-
-		cfg.profiles[cfg.profile].rotator_host = $("#rotator_host").val().trim();
-		cfg.profiles[cfg.profile].rotator_port = $("#rotator_port").val().trim();
 
 		cfg=await ipcRenderer.sendSync("set_config", cfg);
 		updateRotatorPanel();
@@ -117,15 +120,15 @@ $(document).ready(function() {
 
 	$("#config-tab").on("click",function() {
 		const obj={};
-		obj.width=430;
-		obj.height=600;
+		obj.width=WINDOW_WIDTH;
+		obj.height=TAB_HEIGHT_CONFIG;
 		obj.ani=false;
 		resizeme(obj);
 	});
 
 	$("#status-tab").on("click",function() {
 		const obj={};
-		obj.width=430;
+		obj.width=WINDOW_WIDTH;
 		obj.height=getStatusTabHeight();
 		obj.ani=false;
 		resizeme(obj);
@@ -171,13 +174,73 @@ $(document).ready(function() {
 
 	// Rotator follow mode
 	$('input[name="rotator_follow"]').on('change', function() {
-		ipcRenderer.sendSync('rotator_set_follow', $(this).val());
+		const mode = $(this).val();
+		ipcRenderer.sendSync('rotator_set_follow', mode);
+
+		// Show/hide position displays based on mode
+		if (mode === 'hf') {
+			$('#rotator_hf_az').show();
+			$('#rotator_sat_pos').hide();
+		} else if (mode === 'sat') {
+			$('#rotator_hf_az').hide();
+			$('#rotator_sat_pos').show();
+		} else {
+			$('#rotator_hf_az').hide();
+			$('#rotator_sat_pos').hide();
+		}
+	});
+
+	// Park button handler
+	$('#rot_park').on('click', async function() {
+		const profile = cfg.profiles[active_cfg];
+		if (!(profile.rotator_host || '').trim()) {
+			return; // Not configured
+		}
+
+		// Disable button while parking
+		$(this).prop('disabled', true).text('Parking...');
+
+		try {
+			// First, switch to Off mode to stop WebSocket message processing
+			ipcRenderer.sendSync('rotator_set_follow', 'off');
+			$('input[name="rotator_follow"][value="off"]').prop('checked', true);
+
+			// Then connect and send to park
+			await ipcRenderer.invoke('rotator_park', profile);
+		} finally {
+			// Re-enable button
+			$(this).prop('disabled', false).text('Park');
+		}
 	});
 
 	// Advanced settings modal event listeners
 	$('#advanced').click(openAdvancedModal);
 	$('#advancedSave').click(saveAdvancedSettings);
 	$('#advancedCancel').click(() => $('#advancedModal').modal('hide'));
+
+	// Rotator settings modal event listeners
+	$('#rotatorSettings').click(openRotatorModal);
+	$('#rotatorSave').click(saveRotatorSettings);
+	$('#rotatorCancel').click(closeRotatorModal);
+
+	// Handle rotator modal close via X button, backdrop click, or API call
+	$('#rotatorModal').on('hidden.bs.modal', function () {
+		if (originalWindowSize) {
+			// Restore appropriate window size based on current tab
+			const isConfigTab = $('#config').hasClass('active');
+			const isStatusTab = $('#status').hasClass('active');
+			let targetHeight = originalWindowSize.height;
+
+			if (isStatusTab) {
+				targetHeight = getStatusTabHeight();
+			} else if (isConfigTab) {
+				targetHeight = TAB_HEIGHT_CONFIG;
+			}
+
+			resizeme({ width: originalWindowSize.width, height: targetHeight, ani: false });
+			originalWindowSize = null;
+		}
+	});
 });
 
 async function load_config() {
@@ -203,8 +266,6 @@ async function load_config() {
 	// Update radio fields based on selection
 	updateRadioFields();
 
-	$("#rotator_host").val(cfg.profiles[active_cfg].rotator_host || '');
-	$("#rotator_port").val(cfg.profiles[active_cfg].rotator_port || '4533');
 	// Reset follow toggle to Off when loading a profile
 	$('input[name="rotator_follow"][value="off"]').prop('checked', true);
 	ipcRenderer.sendSync('rotator_set_follow', 'off');
@@ -224,23 +285,13 @@ function resizeme(size) {
 }
 
 function getStatusTabHeight() {
-	const hasRotator = cfg.profiles && cfg.profiles[active_cfg] &&
-	                   (cfg.profiles[active_cfg].rotator_host || '').trim() !== '';
-	return hasRotator ? 310 : 250;
+	return TAB_HEIGHT_STATUS;
 }
 
 function updateRotatorPanel() {
-	const hasRotator = (cfg.profiles[active_cfg].rotator_host || '').trim() !== '';
-	if (hasRotator) {
-		const host = cfg.profiles[active_cfg].rotator_host;
-		const port = cfg.profiles[active_cfg].rotator_port || '4533';
-		$('#rotator_status').text(`${host}:${port}`).css('color', '#888');
-		$('#rotator_panel').show();
-	} else {
-		$('#rotator_panel').hide();
-	}
+	updateRotatorPanelVisibility();
 	if ($('#status').hasClass('active')) {
-		resizeme({ width: 430, height: hasRotator ? 310 : 250, ani: false });
+		resizeme({ width: WINDOW_WIDTH, height: getStatusTabHeight(), ani: false });
 	}
 }
 
@@ -814,6 +865,68 @@ async function saveAdvancedSettings() {
 	updateUdpStatus();
 
 	$('#advancedModal').modal('hide');
+}
+
+let originalWindowSize = null;
+
+function openRotatorModal() {
+	const profile = cfg.profiles[active_cfg];
+	$("#modal_rotator_host").val(profile.rotator_host || '');
+	$("#modal_rotator_port").val(profile.rotator_port || '4533');
+	$("#rotator_threshold_az").val(profile.rotator_threshold_az || 2);
+	$("#rotator_threshold_el").val(profile.rotator_threshold_el || 2);
+	$("#rotator_park_az").val(profile.rotator_park_az !== undefined ? profile.rotator_park_az : 0);
+	$("#rotator_park_el").val(profile.rotator_park_el !== undefined ? profile.rotator_park_el : 0);
+
+	originalWindowSize = ipcRenderer.sendSync("get_window_size");
+	resizeme({ width: originalWindowSize.width, height: MODAL_HEIGHT, ani: false });
+
+	$('#rotatorModal').modal('show');
+}
+
+async function saveRotatorSettings() {
+	const profile = cfg.profiles[active_cfg];
+	profile.rotator_host = $("#modal_rotator_host").val().trim();
+	profile.rotator_port = $("#modal_rotator_port").val() || '4533';
+	profile.rotator_threshold_az = parseFloat($("#rotator_threshold_az").val()) || 2;
+	profile.rotator_threshold_el = parseFloat($("#rotator_threshold_el").val()) || 2;
+	profile.rotator_park_az = parseFloat($("#rotator_park_az").val()) || 0;
+	profile.rotator_park_el = parseFloat($("#rotator_park_el").val()) || 0;
+
+	cfg = await ipcRenderer.sendSync("set_config", cfg);
+
+	updateRotatorPanelVisibility();
+
+	closeRotatorModal();
+}
+
+function closeRotatorModal() {
+	$('#rotatorModal').modal('hide');
+}
+
+function updateRotatorPanelVisibility() {
+	const profile = cfg.profiles[active_cfg];
+	const hasRotator = (profile.rotator_host || '').trim() !== '';
+	if (hasRotator) {
+		const host = profile.rotator_host;
+		const port = profile.rotator_port || '4533';
+		$('#rotator_status').text(`${host}:${port}`).css('color', '#888');
+		$('#rotator_current').show();
+		$('#rotator_hint').hide();
+		$('input[name="rotator_follow"]').parent().show();
+		$('#rot_park').show();
+		$('#rotator_hf_az').show();
+		$('#rotator_sat_pos').show();
+	} else {
+		$('#rotator_status').text('Not configured').css('color', '#666');
+		$('#rotator_current').hide();
+		$('#rotator_hint').show();
+		$('input[name="rotator_follow"]').parent().hide();
+		$('#rot_park').hide();
+		$('#rotator_hf_az').hide();
+		$('#rotator_sat_pos').hide();
+	}
+	$('#rotator_panel').show();
 }
 
 function updateUdpStatus() {

--- a/renderer.js
+++ b/renderer.js
@@ -29,7 +29,7 @@ let lastCat=0;
 
 // Window size constants
 const WINDOW_WIDTH = 430;
-const TAB_HEIGHT_CONFIG = 500;
+const TAB_HEIGHT_CONFIG = 550;
 const TAB_HEIGHT_STATUS = 320;
 const MODAL_HEIGHT = 600;
 

--- a/renderer.js
+++ b/renderer.js
@@ -69,7 +69,11 @@ $(document).ready(function() {
 				break;
 		}
 
+		cfg.profiles[cfg.profile].rotator_host = $("#rotator_host").val().trim();
+		cfg.profiles[cfg.profile].rotator_port = $("#rotator_port").val().trim();
+
 		cfg=await ipcRenderer.sendSync("set_config", cfg);
+		updateRotatorPanel();
 	});
 
 	bt_quit.addEventListener('click', () => {
@@ -114,7 +118,7 @@ $(document).ready(function() {
 	$("#config-tab").on("click",function() {
 		const obj={};
 		obj.width=430;
-		obj.height=550;
+		obj.height=600;
 		obj.ani=false;
 		resizeme(obj);
 	});
@@ -122,7 +126,7 @@ $(document).ready(function() {
 	$("#status-tab").on("click",function() {
 		const obj={};
 		obj.width=430;
-		obj.height=250;
+		obj.height=getStatusTabHeight();
 		obj.ani=false;
 		resizeme(obj);
 	});
@@ -165,6 +169,11 @@ $(document).ready(function() {
 		deleteProfile(index);
 	});
 
+	// Rotator follow mode
+	$('input[name="rotator_follow"]').on('change', function() {
+		ipcRenderer.sendSync('rotator_set_follow', $(this).val());
+	});
+
 	// Advanced settings modal event listeners
 	$('#advanced').click(openAdvancedModal);
 	$('#advancedSave').click(saveAdvancedSettings);
@@ -194,6 +203,13 @@ async function load_config() {
 	// Update radio fields based on selection
 	updateRadioFields();
 
+	$("#rotator_host").val(cfg.profiles[active_cfg].rotator_host || '');
+	$("#rotator_port").val(cfg.profiles[active_cfg].rotator_port || '4533');
+	// Reset follow toggle to Off when loading a profile
+	$('input[name="rotator_follow"][value="off"]').prop('checked', true);
+	ipcRenderer.sendSync('rotator_set_follow', 'off');
+	updateRotatorPanel();
+
 	if (cfg.profiles[active_cfg].wavelog_key != "" && cfg.profiles[active_cfg].wavelog_url != "") {
 		getStations();
 	}
@@ -205,6 +221,27 @@ async function load_config() {
 function resizeme(size) {
 	x=(ipcRenderer.sendSync("resize", size))
 	return x;
+}
+
+function getStatusTabHeight() {
+	const hasRotator = cfg.profiles && cfg.profiles[active_cfg] &&
+	                   (cfg.profiles[active_cfg].rotator_host || '').trim() !== '';
+	return hasRotator ? 310 : 250;
+}
+
+function updateRotatorPanel() {
+	const hasRotator = (cfg.profiles[active_cfg].rotator_host || '').trim() !== '';
+	if (hasRotator) {
+		const host = cfg.profiles[active_cfg].rotator_host;
+		const port = cfg.profiles[active_cfg].rotator_port || '4533';
+		$('#rotator_status').text(`${host}:${port}`).css('color', '#888');
+		$('#rotator_panel').show();
+	} else {
+		$('#rotator_panel').hide();
+	}
+	if ($('#status').hasClass('active')) {
+		resizeme({ width: 430, height: hasRotator ? 310 : 250, ani: false });
+	}
 }
 
 function select(selector) {
@@ -250,6 +287,30 @@ function updateRadioFields() {
 			break;
 	}
 }
+
+ipcRenderer.on('rotator_bearing', (event, data) => {
+	if (data.type === 'hf') {
+		$('#rotator_hf_az').text(`Az: ${data.az}°`);
+	} else if (data.type === 'sat') {
+		$('#rotator_sat_pos').text(`Az: ${data.az}°  El: ${data.el}°`);
+	}
+});
+
+ipcRenderer.on('rotator_position', (event, data) => {
+	const elStr = (data.el !== undefined && data.el !== 0) ? `  El: ${parseFloat(data.el).toFixed(1)}°` : '';
+	$('#rotator_current').text(`Az: ${parseFloat(data.az).toFixed(1)}°${elStr}`);
+});
+
+ipcRenderer.on('rotator_update', (event, data) => {
+	if (data.connected !== undefined) {
+		const statusEl = $('#rotator_status');
+		if (data.connected) {
+			statusEl.text('✓ connected').css('color', '#28a745');
+		} else {
+			statusEl.text('✗ offline').css('color', '#dc3545');
+		}
+	}
+});
 
 window.TX_API.onUpdateMsg((value) => {
 	$("#msg").html(value);


### PR DESCRIPTION
This adds Rotator-Control to the Gate.
All functions to have the exact data (SAT-Tracking AND HF-Bearing) are already at the gate (ONLY via Websocket!)
So the "only" thing which was missing was the logic to interface hamlib.
Here we go.

UI:
<img width="426" height="321" alt="image" src="https://github.com/user-attachments/assets/1d2f2084-5e97-4dd0-bb78-c5770ec73790" />

With clicking on the little Antenna-Icon the setup-modal is opened. Inputs:
- rotctld server adress and port
- park position
- thresholds when antenna should move (usually 2degrees)
Settings are saved per profle

After filling in the parameters and pressing save the 4 Items are visible:
- Off - means "Off" - no active interaction with rotator.
- HF - means: Once a Lookup at Wavelog has been performed the Rotator moves to the bearing which was fetched from the callbook. You can change the bearing by typing in a new Call during movement (Antenna stops and moves to that direction)
- SAT - means: If a SAT is given in WL (with proper TLEs) at SAT-Tab, the Az/Ele-Rotator tracks that satellite (as long as it is visible)
- Park - means: Immediatly stop responding to whats coming from wavelog. Move Antenna to park-position set at config.

Testing this beauty is also possible without a real rotator.
Download and install hamlib. Especially `rotctld`. you can start it on your machine either with the proper settings for your real rotator or a dummy-rotator: `rotctld -m 1` starts it on localhost (127.0.0.1) with dummy-backend.

Keep in mind:
- Wavelog needs a connection to the Gate (Tab Station / Radio set to Websocket)
- WavelogGate needs a connection to rotctld mentioned before
- The callbook you're using should provide a Maidenhead-Locator to derive the exact bearing.