### PR TITLE
fix: preserve passband when sending mode command

### DIFF
--- a/main.js
+++ b/main.js
@@ -1694,7 +1694,7 @@ async function settrx(qrg, mode = '') {
 		const client = net.createConnection({ host: defaultcfg.profiles[defaultcfg.profile ?? 0].hamlib_host, port: defaultcfg.profiles[defaultcfg.profile ?? 0].hamlib_port }, () => {
 			client.write("F " + to.qrg + "\n");
 			if (defaultcfg.profiles[defaultcfg.profile ?? 0].wavelog_pmode) {
-				client.write("M " + to.mode + " 0\n");
+				client.write("M " + to.mode + " -1\n");
 			}
 			client.end();
 		});


### PR DESCRIPTION
Fixes #116

When sending the Hamlib mode command, using width 0 forces the rig to the minimum passband on TS590. Switching this argument to -1 keeps the current passband while still applying the mode change.

Greetings, saschabuehrle