### PR TITLE
Emit WL-native QSOs via UDP

### DIFF
--- a/app.go
+++ b/app.go
@@ -157,6 +157,22 @@ func (a *App) startup(ctx context.Context) {
 			}
 			debug.Log("[WS] satellite_position: az=%.1f el=%.1f → HandleWSCommand", az, el)
 			a.rotator.HandleWSCommand(az, el, "sat")
+		case "qso_logged":
+			if !a.cfg.UDPEmitEnabled {
+				return
+			}
+			var p struct {
+				Data struct {
+					ADIF string `json:"adif"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(data, &p); err != nil || p.Data.ADIF == "" {
+				debug.Log("[WS] qso_logged: bad payload: %v", err)
+				return
+			}
+			if err := udp.Emit(a.cfg.UDPEmitHost, a.cfg.UDPEmitPort, p.Data.ADIF); err != nil {
+				debug.Log("[WS] qso_logged: emit error: %v", err)
+			}
 		default:
 			debug.Log("[WS] unhandled type=%s", msgType)
 		}
@@ -409,10 +425,13 @@ func (a *App) SwitchProfile(index int) error {
 
 // UDPStatus holds current UDP server status.
 type UDPStatus struct {
-	Enabled        bool `json:"enabled"`
-	Port           int  `json:"port"`
-	Running        bool `json:"running"`
-	MinimapEnabled bool `json:"minimapEnabled"`
+	Enabled        bool   `json:"enabled"`
+	Port           int    `json:"port"`
+	Running        bool   `json:"running"`
+	MinimapEnabled bool   `json:"minimapEnabled"`
+	EmitEnabled    bool   `json:"emitEnabled"`
+	EmitPort       int    `json:"emitPort"`
+	EmitHost       string `json:"emitHost"`
 }
 
 // GetUDPStatus returns the current UDP server status.
@@ -422,6 +441,9 @@ func (a *App) GetUDPStatus() UDPStatus {
 		Port:           a.cfg.UDPPort,
 		Running:        a.udpSrv != nil,
 		MinimapEnabled: a.cfg.MinimapEnabled,
+		EmitEnabled:    a.cfg.UDPEmitEnabled,
+		EmitPort:       a.cfg.UDPEmitPort,
+		EmitHost:       a.cfg.UDPEmitHost,
 	}
 }
 
@@ -480,10 +502,16 @@ func (a *App) RotatorPark() {
 }
 
 // SaveAdvanced saves global (non-profile) settings.
-func (a *App) SaveAdvanced(udpEnabled bool, udpPort int, minimapEnabled bool) error {
+func (a *App) SaveAdvanced(udpEnabled bool, udpPort int, minimapEnabled bool, emitEnabled bool, emitPort int, emitHost string) error {
+	if udpEnabled && emitEnabled && udpPort == emitPort {
+		return fmt.Errorf("emit port must differ from the listener port (%d)", udpPort)
+	}
 	a.cfg.UDPEnabled = udpEnabled
 	a.cfg.UDPPort = udpPort
 	a.cfg.MinimapEnabled = minimapEnabled
+	a.cfg.UDPEmitEnabled = emitEnabled
+	a.cfg.UDPEmitPort = emitPort
+	a.cfg.UDPEmitHost = emitHost
 	_ = config.Save(a.cfg)
 
 	wailsruntime.EventsEmit(a.ctx, "advanced:changed", map[string]interface{}{

--- a/frontend/src/components/config/AdvancedModal.svelte
+++ b/frontend/src/components/config/AdvancedModal.svelte
@@ -7,18 +7,26 @@
   let advUdpEnabled = true;
   let advUdpPort = 2333;
   let advMinimapEnabled = false;
+  let advEmitEnabled = false;
+  let advEmitPort = 2334;
+  let advEmitHost = "127.0.0.1";
   let advStatus = "";
+
+  $: portClash = advUdpEnabled && advEmitEnabled && advUdpPort === advEmitPort;
 
   onMount(async () => {
     const status = await GetUDPStatus();
     advUdpEnabled = status.enabled;
     advUdpPort = status.port;
     advMinimapEnabled = status.minimapEnabled;
+    advEmitEnabled = status.emitEnabled;
+    advEmitPort = status.emitPort;
+    advEmitHost = status.emitHost;
   });
 
   async function save() {
     try {
-      await SaveAdvanced(advUdpEnabled, advUdpPort, advMinimapEnabled);
+      await SaveAdvanced(advUdpEnabled, advUdpPort, advMinimapEnabled, advEmitEnabled, advEmitPort, advEmitHost);
       advStatus = "Saved ✓";
       setTimeout(() => {
         advStatus = "";
@@ -59,6 +67,41 @@
         disabled={!advUdpEnabled}
       />
     </div>
+
+    <div class="flex items-center gap-1.5 mb-1 mt-2 border-t border-stroke-section pt-2">
+      <label>
+        <input type="checkbox" bind:checked={advEmitEnabled} />
+        UDP QSO Emit enabled
+      </label>
+    </div>
+
+    <div class="flex items-center gap-1.5 mb-1">
+      <label class="w-field-xs flex-shrink-0 text-fg-label text-2xs justify-end" for="adv-emit-host">Emit Host</label>
+      <input
+        id="adv-emit-host"
+        type="text"
+        class="flex-1"
+        bind:value={advEmitHost}
+        disabled={!advEmitEnabled}
+      />
+    </div>
+
+    <div class="flex items-center gap-1.5 mb-1">
+      <label class="w-field-xs flex-shrink-0 text-fg-label text-2xs justify-end" for="adv-emit-port">Emit Port</label>
+      <input
+        id="adv-emit-port"
+        type="number"
+        class="flex-none w-field-xs"
+        bind:value={advEmitPort}
+        min="1024"
+        max="65535"
+        disabled={!advEmitEnabled}
+      />
+    </div>
+
+    {#if portClash}
+      <div class="alert alert-danger mt-1">Emit port must differ from the listener port ({advUdpPort})</div>
+    {/if}
 
     <div class="flex items-center gap-1.5 mb-1 mt-2 border-t border-stroke-section pt-2">
       <label>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -44,7 +44,7 @@ export function RotatorPark():Promise<void>;
 
 export function RotatorSetFollow(arg1:string):Promise<void>;
 
-export function SaveAdvanced(arg1:boolean,arg2:number,arg3:boolean):Promise<void>;
+export function SaveAdvanced(arg1:boolean,arg2:number,arg3:boolean,arg4:boolean,arg5:number,arg6:string):Promise<void>;
 
 export function SaveConfig(arg1:config.Config):Promise<config.Config>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -78,8 +78,8 @@ export function RotatorSetFollow(arg1) {
   return window['go']['main']['App']['RotatorSetFollow'](arg1);
 }
 
-export function SaveAdvanced(arg1, arg2, arg3) {
-  return window['go']['main']['App']['SaveAdvanced'](arg1, arg2, arg3);
+export function SaveAdvanced(arg1, arg2, arg3, arg4, arg5, arg6) {
+  return window['go']['main']['App']['SaveAdvanced'](arg1, arg2, arg3, arg4, arg5, arg6);
 }
 
 export function SaveConfig(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -108,6 +108,9 @@ export namespace config {
 	    udp_enabled: boolean;
 	    udp_port: number;
 	    minimap_enabled: boolean;
+	    udp_emit_enabled: boolean;
+	    udp_emit_port: number;
+	    udp_emit_host: string;
 	    profiles: Profile[];
 	
 	    static createFrom(source: any = {}) {
@@ -122,6 +125,9 @@ export namespace config {
 	        this.udp_enabled = source["udp_enabled"];
 	        this.udp_port = source["udp_port"];
 	        this.minimap_enabled = source["minimap_enabled"];
+	        this.udp_emit_enabled = source["udp_emit_enabled"];
+	        this.udp_emit_port = source["udp_emit_port"];
+	        this.udp_emit_host = source["udp_emit_host"];
 	        this.profiles = this.convertValues(source["profiles"], Profile);
 	    }
 	
@@ -242,6 +248,9 @@ export namespace main {
 	    port: number;
 	    running: boolean;
 	    minimapEnabled: boolean;
+	    emitEnabled: boolean;
+	    emitPort: number;
+	    emitHost: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new UDPStatus(source);
@@ -253,6 +262,9 @@ export namespace main {
 	        this.port = source["port"];
 	        this.running = source["running"];
 	        this.minimapEnabled = source["minimapEnabled"];
+	        this.emitEnabled = source["emitEnabled"];
+	        this.emitPort = source["emitPort"];
+	        this.emitHost = source["emitHost"];
 	    }
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,9 @@ type Config struct {
 	UDPEnabled     bool      `json:"udp_enabled"`
 	UDPPort        int       `json:"udp_port"`
 	MinimapEnabled bool      `json:"minimap_enabled"`
+	UDPEmitEnabled bool      `json:"udp_emit_enabled"`
+	UDPEmitPort    int       `json:"udp_emit_port"`
+	UDPEmitHost    string    `json:"udp_emit_host"`
 	Profiles       []Profile `json:"profiles"`
 }
 
@@ -78,12 +81,15 @@ func defaultProfile() Profile {
 
 func Default() Config {
 	return Config{
-		Version:        5,
+		Version:        6,
 		Profile:        0,
 		ProfileNames:   []string{"Profile 1", "Profile 2"},
 		UDPEnabled:     true,
 		UDPPort:        2333,
 		MinimapEnabled: false,
+		UDPEmitEnabled: false,
+		UDPEmitPort:    2334,
+		UDPEmitHost:    "127.0.0.1",
 		Profiles:       []Profile{defaultProfile(), defaultProfile()},
 	}
 }
@@ -161,6 +167,15 @@ func migrate(cfg Config) Config {
 	if cfg.Version < 5 {
 		cfg.Version = 5
 		// New hamlib managed fields default to zero values (disabled).
+	}
+	if cfg.Version < 6 {
+		cfg.Version = 6
+		if cfg.UDPEmitPort == 0 {
+			cfg.UDPEmitPort = 2334
+		}
+		if cfg.UDPEmitHost == "" {
+			cfg.UDPEmitHost = "127.0.0.1"
+		}
 	}
 	return cfg
 }

--- a/internal/udp/emitter.go
+++ b/internal/udp/emitter.go
@@ -1,0 +1,21 @@
+package udp
+
+import (
+	"fmt"
+	"net"
+)
+
+// Emit sends data as a single UDP datagram to host:port.
+func Emit(host string, port int, data string) error {
+	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", host, port))
+	if err != nil {
+		return err
+	}
+	conn, err := net.DialUDP("udp", nil, addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, err = conn.Write([]byte(data))
+	return err
+}


### PR DESCRIPTION
Sometimes it's useful to broadcast logged QSO to UDP/2333.
e.g.: WWA-Tool, which needs that information, or simply different (local) logbook-application.

This one introduces a new Advanced-Option (see screenshot):
<img width="424" height="414" alt="image" src="https://github.com/user-attachments/assets/273a5eff-9946-4b89-9071-6d2a4285a39e" />

if enabled, WavelogGate will emit QSOs which are logged WITHIN Wavelog (not via WavelogGate - only NATIVE Wavelog, otherwise you'd build a loop) locally to the configured Host/Port as ADIF-Packet.

Demo:

https://github.com/user-attachments/assets/68bb014e-7d77-4c27-b472-d104703bdcca

