### PR TITLE
fix httphandler - cmux filtering caused process to freeze

### DIFF
--- a/internal/qsy/server.go
+++ b/internal/qsy/server.go
@@ -114,7 +114,7 @@ func (s *Server) ListenAndServePolyglot(addr, certFile, keyFile string) error {
 
 	m := cmux.New(ln)
 	tlsL := m.Match(cmux.TLS())
-	httpL := m.Match(cmux.HTTP1Fast(), cmux.HTTP2())
+	httpL := m.Match(cmux.Any())
 
 	go http.Serve(httpL, s)                         //nolint:errcheck
 	go http.Serve(tls.NewListener(tlsL, tlsCfg), s) //nolint:errcheck


### PR DESCRIPTION
cmux matches the first bytes and does not wait for the rest of the data. this works great for normal requests. on the ajax call from the dxcluster however we do a http/https request to localhost. While working on https://github.com/wavelog/wavelog/pull/3185 it happened very often that the cmux filtering did not it's job and the request felt through this filter which cause the process to freeze. No requests prossible. Since we have only one handler `s *Server` we don't need this filtering here  and `Any()` is just fine. This also prevents the process to become deadlocked. 

