### PR TITLE
break at RPRT instead of waiting for the timeout

### DIFF
--- a/internal/radio/client.go
+++ b/internal/radio/client.go
@@ -441,7 +441,10 @@ func (c *HamlibClient) GetModes() ([]string, error) {
 	for {
 		line, err := reader.ReadString('\n')
 		line = strings.TrimSpace(line)
-		if line != "" && !strings.HasPrefix(line, "RPRT") {
+		if strings.HasPrefix(line, "RPRT") {
+			break
+		}
+		if line != "" {
 			parts := strings.Fields(line)
 			modes = append(modes, parts...)
 		}


### PR DESCRIPTION
`GetModes()` asks hamlib to return all modes. hamlib does that and ends its response with `RPRT`. We can break here instead waiting for the 3 second timeout. Otherwise hamlib keeps the connection open and ReadString kills at the timeout 