### PR TITLE
publish waveloggate in aur fully automated on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,3 +225,41 @@ jobs:
             artifacts/WavelogGate-windows-arm64/WavelogGate-windows-arm64.exe
             artifacts/WavelogGate-linux-amd64-webkit4.0/*.deb
             artifacts/WavelogGate-linux-amd64-webkit4.1/*.deb
+
+  aur:
+    needs: release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Update pkgver
+        run: |
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" aur/waveloggate-git/PKGBUILD
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" aur/waveloggate-bin/PKGBUILD
+
+      - name: Publish waveloggate-git to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v3
+        with:
+          pkgname: waveloggate-git
+          pkgbuild: aur/waveloggate-git/PKGBUILD
+          commit_username: ${{ github.actor }}
+          commit_email: fabian.berg@hb9hil.org
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: Update to v${{ env.VERSION }}
+          updpkgsums: true
+
+      - name: Publish waveloggate-bin to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v3
+        with:
+          pkgname: waveloggate-bin
+          pkgbuild: aur/waveloggate-bin/PKGBUILD
+          commit_username: ${{ github.actor }}
+          commit_email: fabian.berg@hb9hil.org
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: Update to v${{ env.VERSION }}
+          updpkgsums: true

--- a/aur/waveloggate-bin/PKGBUILD
+++ b/aur/waveloggate-bin/PKGBUILD
@@ -1,0 +1,34 @@
+pkgname=waveloggate-bin
+pkgver=0.0.0
+pkgrel=1
+pkgdesc="CAT and WSJT-X Bridge for WaveLog (prebuilt binary)"
+arch=('x86_64')
+url="https://github.com/wavelog/WaveLogGate"
+license=('MIT')
+depends=(
+    'webkit2gtk-4.1'
+    'gtk3'
+    'hamlib'
+)
+provides=('waveloggate')
+conflicts=('waveloggate' 'waveloggate-git')
+options=(!strip !lto !debug)
+source=("waveloggate-${pkgver}.deb::${url}/releases/download/v${pkgver}/wavelog-gate_${pkgver}_webkit4.1_amd64.deb")
+sha256sums=('SKIP')
+
+prepare() {
+    # makepkg/bsdtar unpacks the outer .deb (ar archive); extract the payload.
+    bsdtar -xf data.tar.* -C "${srcdir}"
+}
+
+package() {
+    install -Dm755 "${srcdir}/usr/local/bin/wavelog-gate" "${pkgdir}/usr/bin/wavelog-gate"
+    install -Dm644 "${srcdir}/usr/share/applications/wavelog-gate.desktop" \
+        "${pkgdir}/usr/share/applications/wavelog-gate.desktop"
+    install -Dm644 "${srcdir}/usr/share/icons/hicolor/256x256/apps/wavelog-gate.png" \
+        "${pkgdir}/usr/share/icons/hicolor/256x256/apps/wavelog-gate.png"
+
+    # The upstream .desktop points at /usr/local/bin; fix it for the Arch layout.
+    sed -i 's|/usr/local/bin/wavelog-gate|/usr/bin/wavelog-gate|' \
+        "${pkgdir}/usr/share/applications/wavelog-gate.desktop"
+}

--- a/aur/waveloggate-git/PKGBUILD
+++ b/aur/waveloggate-git/PKGBUILD
@@ -1,0 +1,50 @@
+pkgname=waveloggate-git
+pkgdesc="CAT and WSJT-X Bridge for WaveLog"
+pkgver=0.0.0
+pkgrel=1
+arch=('x86_64')
+makedepends=(
+    'git'
+)
+depends=(
+    'go'
+    'wails'
+    'bun'
+    'webkit2gtk-4.1'
+    'hamlib'
+)
+url="https://github.com/wavelog/WaveLogGate"
+license=('MIT')
+# graphic license: MIT
+# source graphic: https://www.wavelog.org/wp-content/uploads/2024/04/wavelog_icon_only.png
+source=(
+    "WaveLogGate::git+https://github.com/wavelog/WaveLogGate#tag=v$pkgver"
+    "WaveLogGate.sh"
+    "WaveLogGate.desktop"
+    "wavelog_icon_only.png"
+)
+sha256sums=('SKIP'
+            '1f42c3eedc034ef363388224d05284b686ba94769650e1a2359f304c849197cb'
+            '593e1c6e902130d0c911e34f5d26f1e4d2703327b814c94ae82be04e1c2d80bb'
+            'aa5da810c4c84cbde4b79445e2fb1195c61d4f9b5c85eafa4bc2867b3d16a39d')
+
+
+options=(!lto !debug)
+# not needed - javascript
+
+build () {
+    cd WaveLogGate
+    wails build -clean -tags webkit2_41
+}
+
+package() {
+    mkdir -p "${pkgdir}/opt/WaveLogGate"
+    mkdir -p "${pkgdir}/usr/share/pixmaps"
+    mkdir -p "${pkgdir}/usr/share/applications/"
+    cp -r WaveLogGate "${pkgdir}/opt"
+    rm -rf "${pkgdir}/opt/WaveLogGate/.git" "${pkgdir}/opt/WaveLogGate/.github" 
+    mkdir -p "${pkgdir}/usr/bin/"
+    install -m755 -Dt "${pkgdir}/usr/bin" "${srcdir}/WaveLogGate.sh"
+    install -m644 -Dt "${pkgdir}/usr/share/applications" "${srcdir}/WaveLogGate.desktop"
+    install -m644 -Dt "${pkgdir}/usr/share/pixmaps" "${srcdir}/wavelog_icon_only.png"
+}

--- a/aur/waveloggate-git/PKGBUILD
+++ b/aur/waveloggate-git/PKGBUILD
@@ -13,6 +13,8 @@ depends=(
     'webkit2gtk-4.1'
     'hamlib'
 )
+provides=('waveloggate')
+conflicts=('waveloggate' 'waveloggate-bin')
 url="https://github.com/wavelog/WaveLogGate"
 license=('MIT')
 # graphic license: MIT


### PR DESCRIPTION
This automates the release of Waveloggate in the AUR. 

Special thanks to @205er and @fabianfrz for manually updating the AUR package for the last few months now. 

Hint for @int2001:
The automated package update to the AUR only runs on tag push triggered releases as we did the last few times. 