### PR TITLE
add Arch Linux package (PKGBUILD, CI build job, docs)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,8 +200,91 @@ jobs:
           name: ${{ matrix.artifact }}
           path: '*.deb'
 
+  build-arch:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux/archlinux:base-devel
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm go bun webkit2gtk-4.1 gtk3 libarchive
+
+      - name: Install Wails CLI
+        run: |
+          GOPATH=/opt/wails-go go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
+          echo "/opt/wails-go/bin" >> "$GITHUB_PATH"
+
+      - name: Determine version
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.version }}" && "${{ inputs.version }}" != "0.0.0-dev" ]]; then
+            VERSION="v${{ inputs.version }}"
+          else
+            VERSION=$(git describe --tags --always 2>/dev/null || echo "vdev")
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: Build
+        run: |
+          export GOPATH=/opt/wails-go
+          wails build -clean -tags webkit2_41 -ldflags "-X main.appVersion=${VERSION}"
+
+      - name: Package (Arch — create .pkg.tar.zst)
+        shell: bash
+        run: |
+          PKG_VER="${VERSION#v}"
+          PKG_DIR="$PWD/_arch_pkgroot"
+          mkdir -p "${PKG_DIR}/usr/bin" \
+                   "${PKG_DIR}/usr/share/applications" \
+                   "${PKG_DIR}/usr/share/icons/hicolor/256x256/apps"
+
+          install -m755 build/bin/WavelogGate "${PKG_DIR}/usr/bin/wavelog-gate"
+          install -m644 build/appicon.png \
+            "${PKG_DIR}/usr/share/icons/hicolor/256x256/apps/wavelog-gate.png"
+
+          printf '%s\n' \
+            '[Desktop Entry]' \
+            'Name=WavelogGate' \
+            'Comment=Amateur radio gateway to Wavelog' \
+            'Exec=/usr/bin/wavelog-gate' \
+            'Icon=wavelog-gate' \
+            'Type=Application' \
+            'Categories=HamRadio;Network;' \
+            'StartupNotify=true' \
+            > "${PKG_DIR}/usr/share/applications/wavelog-gate.desktop"
+
+          INSTALLED_SIZE=$(du -sb "${PKG_DIR}/usr" | cut -f1)
+          BUILDDATE=$(date +%s)
+
+          printf 'pkgname = wavelog-gate\npkgbase = wavelog-gate\npkgver = %s-1\narch = x86_64\nbuilddate = %s\npackager = GitHub Actions\nsize = %s\npkgdesc = Amateur radio gateway connecting WSJT-X/FLDigi and FLRig/Hamlib to Wavelog\nurl = https://github.com/wavelog/WaveLogGate\nlicense = custom\ndepend = webkit2gtk-4.1\ndepend = gtk3\n' \
+            "${PKG_VER}" "${BUILDDATE}" "${INSTALLED_SIZE}" \
+            > "${PKG_DIR}/.PKGINFO"
+
+          printf 'format = 2\npkgname = wavelog-gate\npkgbase = wavelog-gate\npkgver = %s-1\npkgarch = x86_64\npkgbuild_sha256sum = SKIP\npackager = GitHub Actions\nbuilddate = %s\nbuilddir = /build\nbuildtool = makepkg\nbuildtoolver = 7.0.0\n' \
+            "${PKG_VER}" "${BUILDDATE}" \
+            > "${PKG_DIR}/.BUILDINFO"
+
+          PKG_FILE="$PWD/wavelog-gate-${PKG_VER}-1-x86_64.pkg.tar.zst"
+          # cd into the staging dir so archive entries have no leading ./
+          cd "${PKG_DIR}"
+          bsdtar --zstd -cf "${PKG_FILE}" .PKGINFO .BUILDINFO usr
+          cd -
+          echo "PKG_FILE=${PKG_FILE}" >> "$GITHUB_ENV"
+
+      - name: Upload artifact (Arch)
+        uses: actions/upload-artifact@v5
+        with:
+          name: wavelog-gate-arch
+          path: '*.pkg.tar.zst'
+
   release:
-    needs: build
+    needs: [build, build-arch]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.create_release)
     permissions:
@@ -225,3 +308,4 @@ jobs:
             artifacts/WavelogGate-windows-arm64/WavelogGate-windows-arm64.exe
             artifacts/WavelogGate-linux-amd64-webkit4.0/*.deb
             artifacts/WavelogGate-linux-amd64-webkit4.1/*.deb
+            artifacts/wavelog-gate-arch/*.pkg.tar.zst

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 # Build output
+build/arch/pkg/
+build/arch/src/
+build/arch/wavelog-gate-*.pkg.tar.zst
+build/arch/wavelog-gate-*.tar.gz
 build/bin/
 frontend/dist/
 frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -302,6 +302,43 @@ xattr -d com.apple.quarantine /Applications/WavelogGate.app
 
 ---
 
+## Packages
+
+### Arch Linux / CachyOS
+
+A PKGBUILD is provided in [`build/arch/`](build/arch/). It builds from source and targets systems with `webkit2gtk-4.1` (current Arch / CachyOS). All build dependencies (`go`, `bun`) are available in the official repos.
+
+**Build and install:**
+
+```bash
+cd build/arch
+makepkg -si
+```
+
+This downloads the source tarball, installs the Wails CLI via `go install`, builds the binary, and installs:
+- `/usr/bin/wavelog-gate`
+- `/usr/share/applications/wavelog-gate.desktop` (menu entry)
+- `/usr/share/icons/hicolor/256x256/apps/wavelog-gate.png`
+
+Pre-built `.pkg.tar.zst` packages for `x86_64` are also attached to each [GitHub release](https://github.com/wavelog/WaveLogGate/releases). GitHub wraps the download in a `.zip` — unzip it first, then install:
+
+```bash
+unzip wavelog-gate-arch.zip
+sudo pacman -U wavelog-gate-*.pkg.tar.zst
+```
+
+### Debian / Ubuntu
+
+Pre-built `.deb` packages for `amd64` are attached to each [GitHub release](https://github.com/wavelog/WaveLogGate/releases) in two variants:
+- `webkit4.0` — for Ubuntu 22.04 and older Debian-based systems
+- `webkit4.1` — for Ubuntu 24.04 and newer
+
+```bash
+sudo dpkg -i wavelog-gate_<version>_webkit4.1_amd64.deb
+```
+
+---
+
 ## Building from Source
 
 ### Prerequisites

--- a/build/arch/.SRCINFO
+++ b/build/arch/.SRCINFO
@@ -1,0 +1,15 @@
+pkgbase = wavelog-gate
+	pkgdesc = Amateur radio gateway connecting WSJT-X/FLDigi and FLRig/Hamlib to Wavelog
+	pkgver = 2.0.5
+	pkgrel = 1
+	url = https://github.com/wavelog/WaveLogGate
+	arch = x86_64
+	license = custom
+	makedepends = go>=1.23
+	makedepends = bun
+	depends = webkit2gtk-4.1
+	depends = gtk3
+	source = wavelog-gate-2.0.5.tar.gz::https://codeload.github.com/wavelog/WaveLogGate/legacy.tar.gz/refs/tags/v2.0.5
+	sha256sums = 60651917e45df5cc8113e1372e1dce17259d8884a0341affd12586b6da1b5025
+
+pkgname = wavelog-gate

--- a/build/arch/PKGBUILD
+++ b/build/arch/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Joerg <joerg@dj7nt.de>
+pkgname=wavelog-gate
+pkgver=2.0.5
+pkgrel=1
+pkgdesc="Amateur radio gateway connecting WSJT-X/FLDigi and FLRig/Hamlib to Wavelog"
+arch=('x86_64')
+url="https://github.com/wavelog/WaveLogGate"
+license=('custom')
+depends=('webkit2gtk-4.1' 'gtk3')
+makedepends=('go>=1.23' 'bun')
+source=("$pkgname-$pkgver.tar.gz::https://codeload.github.com/wavelog/WaveLogGate/legacy.tar.gz/refs/tags/v$pkgver")
+sha256sums=('60651917e45df5cc8113e1372e1dce17259d8884a0341affd12586b6da1b5025')
+
+prepare() {
+    cd "wavelog-WaveLogGate-"*/
+    export GOPATH="$srcdir/gopath"
+    export GOMODCACHE="$GOPATH/pkg/mod"
+    go install "github.com/wailsapp/wails/v2/cmd/wails@v2.12.0"
+    go mod download
+}
+
+build() {
+    cd "wavelog-WaveLogGate-"*/
+    export GOPATH="$srcdir/gopath"
+    export GOMODCACHE="$GOPATH/pkg/mod"
+    export PATH="$GOPATH/bin:$PATH"
+    export CGO_CPPFLAGS="${CPPFLAGS}"
+    export CGO_CFLAGS="${CFLAGS}"
+    export CGO_CXXFLAGS="${CXXFLAGS}"
+    export CGO_LDFLAGS="${LDFLAGS}"
+    wails build -clean -tags webkit2_41 \
+        -ldflags "-X main.appVersion=v$pkgver" \
+        -trimpath
+}
+
+package() {
+    cd "wavelog-WaveLogGate-"*/
+    install -Dm755 build/bin/WavelogGate "$pkgdir/usr/bin/wavelog-gate"
+    install -Dm644 build/appicon.png \
+        "$pkgdir/usr/share/icons/hicolor/256x256/apps/wavelog-gate.png"
+    printf '%s\n' \
+        '[Desktop Entry]' \
+        'Name=WavelogGate' \
+        'Comment=Amateur radio gateway to Wavelog' \
+        'Exec=/usr/bin/wavelog-gate' \
+        'Icon=wavelog-gate' \
+        'Type=Application' \
+        'Categories=HamRadio;Network;' \
+        'StartupNotify=true' \
+        | install -Dm644 /dev/stdin \
+            "$pkgdir/usr/share/applications/wavelog-gate.desktop"
+}


### PR DESCRIPTION
This makes it simpler to install the package on arch linux (or cachyos). Using either the makepkg or pacman -U with the downloaded package nicely adds the application launcher to the menu.

## Tests

- [x] Ran the `makepkg` as described in the README locally
- [x] Downloaded the build artifact on my machine and installed it using `pacman -U`