### PR TITLE
Buffering

### DIFF
--- a/app.go
+++ b/app.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 
@@ -16,6 +19,7 @@ import (
 	"waveloggate/internal/debug"
 	"waveloggate/internal/hamlib"
 	"waveloggate/internal/qsy"
+	"waveloggate/internal/queue"
 	"waveloggate/internal/radio"
 	"waveloggate/internal/rotator"
 	"waveloggate/internal/startmenu"
@@ -38,6 +42,7 @@ type App struct {
 	wlClient  *wavelog.Client
 	rotator   *rotator.Client
 	hamlibMgr *hamlib.Manager
+	queue     *queue.Queue
 
 	// hamlibStartMu serialises stop+start sequences so that rapid profile
 	// switches (SaveConfig, SwitchProfile) cannot interleave and leave a
@@ -69,6 +74,27 @@ func (a *App) startup(ctx context.Context) {
 
 	// Wavelog client.
 	a.wlClient = wavelog.New(&profile, appVersion)
+
+	// QSO retry queue — buffers ADIF strings that failed transient submission
+	// (net down) and retries them later. Persists across restarts.
+	queuePath, err := queueFilePath()
+	if err != nil {
+		debug.Log("[QUEUE] cannot resolve queue path: %v", err)
+	}
+	a.queue = queue.New(queuePath, a.wlClient,
+		func(r *wavelog.QSOResult) {
+			if a.ctx != nil {
+				wailsruntime.EventsEmit(a.ctx, "qso:result", r)
+			}
+		},
+		func(n int) {
+			if a.ctx != nil {
+				wailsruntime.EventsEmit(a.ctx, "queue:pending", n)
+			}
+		},
+	)
+	a.queue.Load()
+	go a.queue.Run(ctx, 30*time.Second)
 
 	// WebSocket hub.
 	a.wsHub = ws.NewHub()
@@ -297,6 +323,7 @@ func (a *App) startUDPServer(port int) error {
 	a.udpSrv = udp.New(
 		port,
 		a.wlClient,
+		a.queue,
 		&profile,
 		func(result *wavelog.QSOResult) {
 			wailsruntime.EventsEmit(a.ctx, "qso:result", result)
@@ -306,6 +333,15 @@ func (a *App) startUDPServer(port int) error {
 		},
 	)
 	return a.udpSrv.Start()
+}
+
+// queueFilePath returns the on-disk path for the persistent QSO queue.
+func queueFilePath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "WavelogGate", "queue.jsonl"), nil
 }
 
 // emitHamlibError emits a hamlib:status error event to the frontend.
@@ -464,6 +500,30 @@ func (a *App) GetUDPStatus() UDPStatus {
 		EmitEnabled:    a.cfg.UDPEmitEnabled,
 		EmitPort:       a.cfg.UDPEmitPort,
 		EmitHost:       a.cfg.UDPEmitHost,
+	}
+}
+
+// GetQueuePending returns the number of QSOs currently buffered awaiting retry.
+func (a *App) GetQueuePending() int {
+	if a.queue == nil {
+		return 0
+	}
+	return a.queue.Pending()
+}
+
+// RetryNow triggers an immediate drain attempt of the QSO retry queue.
+// Non-blocking; if a drain is already in flight it is a no-op.
+func (a *App) RetryNow() {
+	if a.queue != nil {
+		a.queue.Wake()
+	}
+}
+
+// FlushQueue drops all buffered QSOs and removes the queue file.
+// Lost QSOs cannot be recovered.
+func (a *App) FlushQueue() {
+	if a.queue != nil {
+		a.queue.Flush()
 	}
 }
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -6,11 +6,14 @@
     GetCertInfo,
     GetRotatorStatus,
     GetUDPStatus,
+    GetQueuePending,
     RotatorSetFollow,
     RotatorPark,
     RotatorGoto,
     RadioSetFreq,
     RadioSetTxFreq,
+    RetryNow,
+    FlushQueue,
   } from "../wailsjs/go/main/App.js";
   import StatusTab from "./components/StatusTab.svelte";
   import ConfigTab from "./components/ConfigTab.svelte";
@@ -52,6 +55,7 @@
   let demandedEl    = null;
   let minimapEnabled = false;
   let certInfo      = null;
+  let queuePending  = 0;
 
   // ── Reactive mini-height ───────────────────────────────────────────────────
   $: miniHeight = rotatorEnabled
@@ -94,6 +98,16 @@
   async function park() {
     rotFollow = "off";
     await RotatorPark();
+  }
+
+  async function retryQueue() {
+    await RetryNow();
+  }
+
+  async function flushQueue() {
+    if (!queuePending) return;
+    if (!window.confirm(`Drop ${queuePending} buffered QSO${queuePending === 1 ? "" : "s"}? This cannot be undone.`)) return;
+    await FlushQueue();
   }
 
   function mhzStrToHz(mhzStr) {
@@ -167,7 +181,7 @@
 
   // ── Lifecycle ──────────────────────────────────────────────────────────────
   let offRadio, offQso, offStatus, offRotPos, offRotStatus, offRotBearing,
-      offRotMoving, offRotFollow, offRotGoto, offProfile, offRadioEnabled, offRotEnabled, offAdvanced, offCert;
+      offRotMoving, offRotFollow, offRotGoto, offProfile, offRadioEnabled, offRotEnabled, offAdvanced, offCert, offQueue;
 
   onMount(async () => {
     updateClock();
@@ -222,6 +236,7 @@
       minimapEnabled = data?.minimapEnabled ?? false;
     });
     offCert = EventsOn("cert:install_needed", (data) => { certInfo = data; });
+    offQueue = EventsOn("queue:pending", (n) => { queuePending = n || 0; });
     offRotFollow = EventsOn("rotator:followmode", (mode) => { rotFollow = mode; });
     offRotGoto = EventsOn("rotator:goto", (data) => {
       if (data) { demandedAz = data.az; demandedEl = data.el; _lastRotCmdTime = Date.now(); }
@@ -241,6 +256,10 @@
 
     const adv = await GetUDPStatus();
     minimapEnabled = adv.minimapEnabled;
+
+    try {
+      queuePending = await GetQueuePending();
+    } catch (_) { /* bridge not ready yet */ }
 
     try {
       const ci = await GetCertInfo();
@@ -278,6 +297,7 @@
     if (offRadioEnabled) offRadioEnabled();
     if (offAdvanced)   offAdvanced();
     if (offCert)       offCert();
+    if (offQueue)      offQueue();
   });
 </script>
 
@@ -334,8 +354,11 @@
           {radioEnabled} {rotatorEnabled}
           {rotConnected} {rotMoving} {rotAz} {rotEl} {rotFollow}
           {hfAz} {satAz} {satEl} {demandedAz} {demandedEl}
+          {queuePending}
           on:follow={(e) => setFollow(e.detail)}
           on:park={park}
+          on:retry={retryQueue}
+          on:flush={flushQueue}
           on:freqscroll={handleFreqScroll}
           on:txfreqscroll={handleTxFreqScroll}
           on:rotscroll={handleRotScroll}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -104,9 +104,10 @@
     await RetryNow();
   }
 
+  // Confirmation is the two-step Flush→Sure? button in StatusTab; no native
+  // dialog (window.confirm is a silent no-op in WKWebView on macOS).
   async function flushQueue() {
     if (!queuePending) return;
-    if (!window.confirm(`Drop ${queuePending} buffered QSO${queuePending === 1 ? "" : "s"}? This cannot be undone.`)) return;
     await FlushQueue();
   }
 

--- a/frontend/src/components/StatusTab.svelte
+++ b/frontend/src/components/StatusTab.svelte
@@ -25,6 +25,24 @@
   export let demandedAz = null;
   export let demandedEl = null;
   export let queuePending = 0;
+
+  // Two-step flush confirmation. window.confirm is unusable here: Wails'
+  // WKWebView on macOS has no JS-dialog delegate, so confirm() silently
+  // returns falsy and the button would never fire.
+  let flushArmed = false;
+  let flushArmTimer = null;
+
+  function handleFlushClick() {
+    if (!flushArmed) {
+      flushArmed = true;
+      clearTimeout(flushArmTimer);
+      flushArmTimer = setTimeout(() => { flushArmed = false; }, 4000);
+      return;
+    }
+    clearTimeout(flushArmTimer);
+    flushArmed = false;
+    dispatch("flush");
+  }
 </script>
 
 <div class="py-2.5 px-3 flex flex-col gap-2">
@@ -60,10 +78,12 @@
         on:click={() => dispatch("retry")}
       >Retry now</button>
       <button
-        class="text-2xs py-1 px-2 rounded-md border border-stroke-base text-fg-bright hover:bg-surface-input transition-colors duration-150"
+        class="text-2xs py-1 px-2 rounded-md border transition-colors duration-150 {flushArmed
+          ? 'border-red-500 text-red-400 hover:bg-red-500/10'
+          : 'border-stroke-base text-fg-bright hover:bg-surface-input'}"
         title="Drop all buffered QSOs (cannot be undone)"
-        on:click={() => dispatch("flush")}
-      >Flush</button>
+        on:click={handleFlushClick}
+      >{flushArmed ? "Sure?" : "Flush"}</button>
     </div>
   {/if}
 

--- a/frontend/src/components/StatusTab.svelte
+++ b/frontend/src/components/StatusTab.svelte
@@ -24,6 +24,7 @@
   export let satEl = null;
   export let demandedAz = null;
   export let demandedEl = null;
+  export let queuePending = 0;
 </script>
 
 <div class="py-2.5 px-3 flex flex-col gap-2">
@@ -45,6 +46,24 @@
           </div>
         {/if}
       {/if}
+    </div>
+  {/if}
+
+  {#if queuePending > 0}
+    <div class="px-1 flex items-center gap-2">
+      <div class="alert alert-danger flex-1 font-mono text-2xs">
+        ⏳ {queuePending} QSO{queuePending === 1 ? "" : "s"} queued — will retry every 30s
+      </div>
+      <button
+        class="text-2xs py-1 px-2 rounded-md border border-stroke-base text-fg-bright hover:bg-surface-input transition-colors duration-150"
+        title="Retry sending queued QSOs now"
+        on:click={() => dispatch("retry")}
+      >Retry now</button>
+      <button
+        class="text-2xs py-1 px-2 rounded-md border border-stroke-base text-fg-bright hover:bg-surface-input transition-colors duration-150"
+        title="Drop all buffered QSOs (cannot be undone)"
+        on:click={() => dispatch("flush")}
+      >Flush</button>
     </div>
   {/if}
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,0 +1,236 @@
+// Package queue buffers QSO ADIF strings that failed transient submission
+// (network down) and retries them in FIFO order until success or permanent error.
+package queue
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"waveloggate/internal/debug"
+	"waveloggate/internal/wavelog"
+)
+
+// Queue is a disk-backed FIFO of ADIF strings awaiting submission to Wavelog.
+type Queue struct {
+	mu        sync.Mutex
+	items     []string
+	path      string
+	client    *wavelog.Client
+	wake      chan struct{}
+	onResult  func(*wavelog.QSOResult)
+	onPending func(int)
+}
+
+// New creates a Queue persisted at path. Callbacks are optional; onResult fires
+// per drained QSO, onPending fires with the current size after any change.
+func New(path string, client *wavelog.Client, onResult func(*wavelog.QSOResult), onPending func(int)) *Queue {
+	return &Queue{
+		path:      path,
+		client:    client,
+		wake:      make(chan struct{}, 1), // ponytail: buffered=1 → Wake never blocks
+		onResult:  onResult,
+		onPending: onPending,
+	}
+}
+
+// Load reads any previously persisted queue from disk into memory.
+// Missing file is not an error.
+func (q *Queue) Load() {
+	q.mu.Lock()
+	f, err := os.Open(q.path)
+	if err != nil {
+		q.mu.Unlock()
+		return
+	}
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 65536), 65536)
+	for sc.Scan() {
+		line := sc.Text()
+		if line != "" {
+			q.items = append(q.items, line)
+		}
+	}
+	n := len(q.items)
+	q.mu.Unlock()
+
+	f.Close()
+	debug.Log("[QUEUE] loaded %d pending QSOs from disk", n)
+	q.notifyPending()
+}
+
+// Push appends an ADIF string, persists, and wakes the retry loop.
+func (q *Queue) Push(adif string) {
+	q.mu.Lock()
+	q.items = append(q.items, adif)
+	n := len(q.items)
+	q.mu.Unlock()
+
+	q.persist()
+	q.notifyPending()
+	q.Wake()
+
+	debug.Log("[QUEUE] buffered QSO (%d pending)", n)
+}
+
+// Wake signals the retry loop to attempt a drain immediately.
+// Non-blocking; extra wakes coalesce.
+func (q *Queue) Wake() {
+	select {
+	case q.wake <- struct{}{}:
+	default:
+	}
+}
+
+// Flush drops all buffered QSOs and removes the queue file.
+func (q *Queue) Flush() {
+	q.mu.Lock()
+	q.items = nil
+	q.mu.Unlock()
+
+	_ = os.Remove(q.path)
+	q.notifyPending()
+	debug.Log("[QUEUE] flushed — all pending QSOs dropped")
+}
+
+// Pending returns the current queue depth. Safe for concurrent use.
+func (q *Queue) Pending() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.items)
+}
+
+// Run drains the queue on wake or every retryInterval. Returns when ctx is cancelled.
+// Stops on first transient failure (net still down); continues past permanent failures.
+func (q *Queue) Run(ctx context.Context, retryInterval time.Duration) {
+	t := time.NewTicker(retryInterval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-q.wake:
+			q.drain()
+		case <-t.C:
+			if q.Pending() > 0 {
+				q.drain()
+			}
+		}
+	}
+}
+
+// drain sends every queued QSO in order. Stops at the first transient failure
+// (leaves remaining items queued). Permanent failures are dropped + logged.
+func (q *Queue) drain() {
+	for {
+		q.mu.Lock()
+		if len(q.items) == 0 {
+			q.mu.Unlock()
+			return
+		}
+		adif := q.items[0]
+		q.mu.Unlock()
+
+		result, err := q.client.SendQSO(adif, false)
+		if err != nil {
+			debug.Log("[QUEUE] drain send error: %v (will retry)", err)
+			return // treat client error same as transient — keep, retry later
+		}
+
+		if result.Success {
+			q.shiftHead(adif)
+			if q.onResult != nil {
+				q.onResult(result)
+			}
+			continue
+		}
+
+		if wavelog.IsTransient(result.Reason) {
+			debug.Log("[QUEUE] drain stopped — transient failure: %s", result.Reason)
+			return // net still down; keep item, wait for next wake
+		}
+
+		// Permanent failure: drop to avoid infinite loop on junk.
+		debug.Log("[QUEUE] dropping QSO — permanent failure: %s", result.Reason)
+		q.shiftHead(adif)
+		if q.onResult != nil {
+			q.onResult(result)
+		}
+	}
+}
+
+// shiftHead removes items[0] only if it still equals the item that was just
+// sent. The lock is released across the SendQSO network call, so a concurrent
+// Flush (which nils the slice) or a later Push could have changed the head.
+// Appends never move the head; only a Flush does, and in that case the sent
+// item belonged to a flushed slice and must not mutate the new one.
+func (q *Queue) shiftHead(expected string) {
+	q.mu.Lock()
+	removed := false
+	if len(q.items) > 0 && q.items[0] == expected {
+		q.items = q.items[1:]
+		removed = true
+	}
+	q.mu.Unlock()
+	if removed {
+		q.persist()
+		q.notifyPending()
+	}
+}
+
+// persist rewrites the queue file atomically from the in-memory slice.
+func (q *Queue) persist() {
+	q.mu.Lock()
+	snapshot := make([]string, len(q.items))
+	copy(snapshot, q.items)
+	path := q.path
+	q.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		debug.Log("[QUEUE] persist mkdir error: %v", err)
+		return
+	}
+
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		debug.Log("[QUEUE] persist create error: %v", err)
+		return
+	}
+	w := bufio.NewWriter(f)
+	for _, s := range snapshot {
+		w.WriteString(s)
+		w.WriteByte('\n')
+	}
+	if err := w.Flush(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		debug.Log("[QUEUE] persist flush error: %v", err)
+		return
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		debug.Log("[QUEUE] persist close error: %v", err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		debug.Log("[QUEUE] persist rename error: %v", err)
+		return
+	}
+}
+
+func (q *Queue) notifyPending() {
+	if q.onPending == nil {
+		return
+	}
+	q.mu.Lock()
+	n := len(q.items)
+	q.mu.Unlock()
+	q.onPending(n)
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -17,6 +17,7 @@ import (
 // Queue is a disk-backed FIFO of ADIF strings awaiting submission to Wavelog.
 type Queue struct {
 	mu        sync.Mutex
+	persistMu sync.Mutex // serialises snapshot+write+rename in persist()
 	items     []string
 	path      string
 	client    *wavelog.Client
@@ -92,7 +93,9 @@ func (q *Queue) Flush() {
 	q.items = nil
 	q.mu.Unlock()
 
+	q.persistMu.Lock()
 	_ = os.Remove(q.path)
+	q.persistMu.Unlock()
 	q.notifyPending()
 	debug.Log("[QUEUE] flushed — all pending QSOs dropped")
 }
@@ -184,7 +187,14 @@ func (q *Queue) shiftHead(expected string) {
 }
 
 // persist rewrites the queue file atomically from the in-memory slice.
+// persistMu is held across snapshot+write+rename so that concurrent callers
+// (Push on UDP handler goroutines, shiftHead on the Run goroutine) cannot
+// interleave writes to the shared tmp file or rename an older snapshot over
+// a newer one. Never acquire persistMu while holding q.mu.
 func (q *Queue) persist() {
+	q.persistMu.Lock()
+	defer q.persistMu.Unlock()
+
 	q.mu.Lock()
 	snapshot := make([]string, len(q.items))
 	copy(snapshot, q.items)

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -5,6 +5,7 @@ package queue
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"sync"
@@ -49,17 +50,30 @@ func (q *Queue) Load() {
 	}
 
 	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 0, 65536), 65536)
+	sc.Buffer(make([]byte, 0, 65536), 1024*1024)
 	for sc.Scan() {
 		line := sc.Text()
-		if line != "" {
+		if line == "" {
+			continue
+		}
+		// Items are JSON-encoded strings (newline-safe). Lines that don't
+		// parse are legacy plain-ADIF entries from the pre-JSON format —
+		// keep them verbatim.
+		var s string
+		if err := json.Unmarshal([]byte(line), &s); err == nil {
+			q.items = append(q.items, s)
+		} else {
 			q.items = append(q.items, line)
 		}
 	}
+	scanErr := sc.Err()
 	n := len(q.items)
 	q.mu.Unlock()
 
 	f.Close()
+	if scanErr != nil {
+		debug.Log("[QUEUE] load aborted early: %v — queue file may be truncated", scanErr)
+	}
 	debug.Log("[QUEUE] loaded %d pending QSOs from disk", n)
 	q.notifyPending()
 }
@@ -214,7 +228,14 @@ func (q *Queue) persist() {
 	}
 	w := bufio.NewWriter(f)
 	for _, s := range snapshot {
-		w.WriteString(s)
+		// JSON-encode each item: ADIF values are length-prefixed and may
+		// legally contain newlines, which would break the line-based format.
+		enc, err := json.Marshal(s)
+		if err != nil {
+			debug.Log("[QUEUE] persist marshal error: %v", err)
+			continue
+		}
+		w.Write(enc)
 		w.WriteByte('\n')
 	}
 	if err := w.Flush(); err != nil {

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,0 +1,218 @@
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"waveloggate/internal/config"
+	"waveloggate/internal/wavelog"
+)
+
+// wavelogHandler mimics Wavelog's /api/qso endpoint.
+// mode: "ok" → created, "reject" → permanent reject, "transient" → 500 server error.
+func wavelogHandler(mode string, count *int, mu *sync.Mutex) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]string
+		_ = json.Unmarshal(body, &p)
+
+		mu.Lock()
+		*count++
+		mu.Unlock()
+
+		switch mode {
+		case "ok":
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "created"})
+		case "reject":
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "failed", "reason": "duplicate"})
+		case "transient":
+			http.Error(w, "server error", http.StatusInternalServerError)
+		}
+	})
+}
+
+func newClient(t *testing.T, baseURL string) *wavelog.Client {
+	t.Helper()
+	cfg := &config.Profile{
+		WavelogURL: baseURL + "/index.php",
+		WavelogKey: "testkey",
+		WavelogID:  "1",
+	}
+	return wavelog.New(cfg, "test")
+}
+
+func tmpQueuePath(t *testing.T) string {
+	dir := t.TempDir()
+	return filepath.Join(dir, "queue.jsonl")
+}
+
+// TestQueueDrainSuccess: queue with one item drains successfully when Wavelog is up.
+func TestQueueDrainSuccess(t *testing.T) {
+	var count int
+	var mu sync.Mutex
+	srv := httptest.NewServer(wavelogHandler("ok", &count, &mu))
+	defer srv.Close()
+
+	client := newClient(t, srv.URL)
+	path := tmpQueuePath(t)
+
+	var results []*wavelog.QSOResult
+	var pendingCalls []int
+	q := New(path, client,
+		func(r *wavelog.QSOResult) { results = append(results, r) },
+		func(n int) { pendingCalls = append(pendingCalls, n) },
+	)
+
+	q.Push("<call:5>TEST1 <eor>")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go q.Run(ctx, 100*time.Millisecond)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if q.Pending() == 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if q.Pending() != 0 {
+		t.Fatalf("queue should be empty, has %d", q.Pending())
+	}
+	if len(results) != 1 || !results[0].Success {
+		t.Fatalf("expected 1 successful result, got %+v", results)
+	}
+}
+
+// TestQueueTransientKeepsItem: a transient server failure keeps the item queued.
+func TestQueueTransientKeepsItem(t *testing.T) {
+	var count int
+	var mu sync.Mutex
+	srv := httptest.NewServer(wavelogHandler("transient", &count, &mu))
+	defer srv.Close()
+
+	client := newClient(t, srv.URL)
+	path := tmpQueuePath(t)
+
+	q := New(path, client, nil, nil)
+	q.Push("<call:5>TEST2 <eor>")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	q.Run(ctx, 100*time.Millisecond) // synchronous — should exit on ctx after retries
+
+	if q.Pending() != 1 {
+		t.Fatalf("transient failure should keep item queued, got pending=%d", q.Pending())
+	}
+}
+
+// TestQueuePermanentDropsItem: a permanent Wavelog rejection drops the item.
+func TestQueuePermanentDropsItem(t *testing.T) {
+	var count int
+	var mu sync.Mutex
+	srv := httptest.NewServer(wavelogHandler("reject", &count, &mu))
+	defer srv.Close()
+
+	client := newClient(t, srv.URL)
+	path := tmpQueuePath(t)
+
+	q := New(path, client, nil, nil)
+	q.Push("<call:5>TEST3 <eor>")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go q.Run(ctx, 100*time.Millisecond)
+
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if q.Pending() == 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if q.Pending() != 0 {
+		t.Fatalf("permanent failure should drop item, got pending=%d", q.Pending())
+	}
+}
+
+// TestQueuePersistsAcrossRestart: pushed items survive a New+Load cycle.
+func TestQueuePersistsAcrossRestart(t *testing.T) {
+	path := tmpQueuePath(t)
+
+	q1 := New(path, nil, nil, nil)
+	q1.Push("<call:5>PERSIST1 <eor>")
+	q1.Push("<call:5>PERSIST2 <eor>")
+
+	q2 := New(path, nil, nil, nil)
+	q2.Load()
+
+	if got := q2.Pending(); got != 2 {
+		t.Fatalf("expected 2 items after reload, got %d", got)
+	}
+}
+
+// TestQueueFlush: Flush clears items and removes the file.
+func TestQueueFlush(t *testing.T) {
+	path := tmpQueuePath(t)
+	q := New(path, nil, nil, nil)
+	q.Push("<call:5>FLUSH1 <eor>")
+	q.Push("<call:5>FLUSH2 <eor>")
+
+	q.Flush()
+
+	if got := q.Pending(); got != 0 {
+		t.Fatalf("expected 0 pending after flush, got %d", got)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("queue file should be removed after flush, got err=%v", err)
+	}
+}
+
+// TestQueueWakeTriggersImmediateDrain: Wake on Push triggers drain without waiting for ticker.
+func TestQueueWakeTriggersImmediateDrain(t *testing.T) {
+	var count int
+	var mu sync.Mutex
+	srv := httptest.NewServer(wavelogHandler("ok", &count, &mu))
+	defer srv.Close()
+
+	client := newClient(t, srv.URL)
+	path := tmpQueuePath(t)
+
+	q := New(path, client, nil, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	go q.Run(ctx, 1*time.Hour) // long ticker — only Wake should trigger drain
+
+	q.Push("<call:5>WAKE1 <eor>")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		c := count
+		mu.Unlock()
+		if c >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	c := count
+	mu.Unlock()
+	if c < 1 {
+		t.Fatalf("Wake should trigger immediate drain; server got %d requests", c)
+	}
+	fmt.Println("server received", c, "requests via wake-triggered drain")
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -216,3 +216,54 @@ func TestQueueWakeTriggersImmediateDrain(t *testing.T) {
 	}
 	fmt.Println("server received", c, "requests via wake-triggered drain")
 }
+
+// TestQueueConcurrentPushDrainPersist: concurrent Push (many goroutines, like UDP
+// handlers) racing a draining Run loop must leave the on-disk file consistent —
+// after everything settles, a fresh Load must see exactly the undrained items.
+func TestQueueConcurrentPushDrainPersist(t *testing.T) {
+	var count int
+	var mu sync.Mutex
+	srv := httptest.NewServer(wavelogHandler("ok", &count, &mu))
+	defer srv.Close()
+
+	client := newClient(t, srv.URL)
+	path := tmpQueuePath(t)
+
+	q := New(path, client, nil, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go q.Run(ctx, 50*time.Millisecond)
+
+	const pushers, perPusher = 8, 20
+	var wg sync.WaitGroup
+	for p := 0; p < pushers; p++ {
+		wg.Add(1)
+		go func(p int) {
+			defer wg.Done()
+			for i := 0; i < perPusher; i++ {
+				q.Push(fmt.Sprintf("<call:6>CONC%d%d <eor>", p, i))
+			}
+		}(p)
+	}
+	wg.Wait()
+
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if q.Pending() == 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := q.Pending(); got != 0 {
+		t.Fatalf("queue should fully drain, has %d", got)
+	}
+	cancel()
+
+	// Disk must agree with memory: nothing pending → empty or absent file.
+	q2 := New(path, nil, nil, nil)
+	q2.Load()
+	if got := q2.Pending(); got != 0 {
+		t.Fatalf("on-disk queue inconsistent after concurrent push/drain: reload sees %d items", got)
+	}
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -162,6 +162,46 @@ func TestQueuePersistsAcrossRestart(t *testing.T) {
 	}
 }
 
+// TestQueuePersistsItemWithNewline: ADIF values are length-prefixed and may
+// contain newlines; the line-based file format must survive them intact.
+func TestQueuePersistsItemWithNewline(t *testing.T) {
+	path := tmpQueuePath(t)
+	item := "<call:5>MULTI <comment:11>line1\nline2 <eor>"
+
+	q1 := New(path, nil, nil, nil)
+	q1.Push(item)
+
+	q2 := New(path, nil, nil, nil)
+	q2.Load()
+
+	if got := q2.Pending(); got != 1 {
+		t.Fatalf("expected 1 item after reload, got %d", got)
+	}
+	if q2.items[0] != item {
+		t.Fatalf("item corrupted across restart:\nwant %q\ngot  %q", item, q2.items[0])
+	}
+}
+
+// TestQueueLoadsLegacyPlainLines: queue files written before JSON encoding
+// hold raw ADIF per line; Load must keep them verbatim.
+func TestQueueLoadsLegacyPlainLines(t *testing.T) {
+	path := tmpQueuePath(t)
+	legacy := "<call:6>LEGACY <band:3>20m <eor>"
+	if err := os.WriteFile(path, []byte(legacy+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	q := New(path, nil, nil, nil)
+	q.Load()
+
+	if got := q.Pending(); got != 1 {
+		t.Fatalf("expected 1 legacy item, got %d", got)
+	}
+	if q.items[0] != legacy {
+		t.Fatalf("legacy item mangled:\nwant %q\ngot  %q", legacy, q.items[0])
+	}
+}
+
 // TestQueueFlush: Flush clears items and removes the file.
 func TestQueueFlush(t *testing.T) {
 	path := tmpQueuePath(t)

--- a/internal/udp/server.go
+++ b/internal/udp/server.go
@@ -9,6 +9,7 @@ import (
 	"waveloggate/internal/adif"
 	"waveloggate/internal/config"
 	"waveloggate/internal/debug"
+	"waveloggate/internal/queue"
 	"waveloggate/internal/wavelog"
 )
 
@@ -19,6 +20,7 @@ const maxConcurrentHandlers = 16
 type Server struct {
 	port     int
 	wlClient *wavelog.Client
+	queue    *queue.Queue
 	onResult func(result *wavelog.QSOResult)
 	onStatus func(msg string)
 	conn     *net.UDPConn
@@ -27,11 +29,12 @@ type Server struct {
 	cfg      *config.Profile
 }
 
-// New creates a new UDP server.
-func New(port int, wlClient *wavelog.Client, cfg *config.Profile, onResult func(result *wavelog.QSOResult), onStatus func(msg string)) *Server {
+// New creates a new UDP server. queue may be nil to disable buffering.
+func New(port int, wlClient *wavelog.Client, q *queue.Queue, cfg *config.Profile, onResult func(result *wavelog.QSOResult), onStatus func(msg string)) *Server {
 	return &Server{
 		port:     port,
 		wlClient: wlClient,
+		queue:    q,
 		cfg:      cfg,
 		onResult: onResult,
 		onStatus: onStatus,
@@ -156,11 +159,16 @@ func (s *Server) handleDatagram(data string) {
 	result, err := s.wlClient.SendQSO(adifStr, false)
 	if err != nil {
 		debug.Log("[UDP] SendQSO error: %v", err)
-		result = &wavelog.QSOResult{Success: false, Reason: err.Error()}
+		result = &wavelog.QSOResult{Success: false, Reason: wavelog.ReasonInternet}
 	}
 
 	debug.Log("[UDP] QSO result: success=%v call=%s band=%s mode=%s reason=%s",
 		result.Success, result.Call, result.Band, result.Mode, result.Reason)
+
+	// Buffer transient failures for later retry; permanent errors surface as before.
+	if !result.Success && wavelog.IsTransient(result.Reason) && s.queue != nil {
+		s.queue.Push(adifStr)
+	}
 
 	if s.onResult != nil {
 		s.onResult(result)

--- a/internal/udp/server.go
+++ b/internal/udp/server.go
@@ -158,6 +158,10 @@ func (s *Server) handleDatagram(data string) {
 
 	result, err := s.wlClient.SendQSO(adifStr, false)
 	if err != nil {
+		// Hard client errors (marshal / request build, e.g. malformed URL) are
+		// classified transient too: the QSO gets buffered and retried instead
+		// of being lost, and drains once the profile is fixed. The real error
+		// is only visible in the debug log.
 		debug.Log("[UDP] SendQSO error: %v", err)
 		result = &wavelog.QSOResult{Success: false, Reason: wavelog.ReasonInternet}
 	}

--- a/internal/wavelog/client.go
+++ b/internal/wavelog/client.go
@@ -27,6 +27,19 @@ type QSOResult struct {
 	Reason  string `json:"reason"`
 }
 
+// Reason values classifying SendQSO outcomes. Single source of truth — callers
+// that gate retry/buffering on a reason must use IsTransient, not string literals.
+const (
+	ReasonInternet    = "internet problem"
+	ReasonTimeout     = "timeout"
+	ReasonServerError = "server error"
+)
+
+// IsTransient reports whether a SendQSO reason is worth retrying later.
+func IsTransient(reason string) bool {
+	return reason == ReasonInternet || reason == ReasonTimeout || reason == ReasonServerError
+}
+
 // RadioData holds the data sent to Wavelog's /api/radio endpoint.
 type RadioData struct {
 	Frequency   int64
@@ -126,7 +139,7 @@ func (c *Client) SendQSO(adifStr string, dryRun bool) (*QSOResult, error) {
 
 	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("internet problem")
+		return nil, fmt.Errorf(ReasonInternet)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", c.userAgent)
@@ -135,15 +148,21 @@ func (c *Client) SendQSO(adifStr string, dryRun bool) (*QSOResult, error) {
 	if err != nil {
 		debug.Log("[WL] HTTP error: %v", err)
 		if strings.Contains(err.Error(), "timeout") || strings.Contains(err.Error(), "deadline") {
-			return &QSOResult{Success: false, Reason: "timeout"}, nil
+			return &QSOResult{Success: false, Reason: ReasonTimeout}, nil
 		}
-		return &QSOResult{Success: false, Reason: "internet problem"}, nil
+		return &QSOResult{Success: false, Reason: ReasonInternet}, nil
 	}
 	defer resp.Body.Close()
 
 	data, _ := io.ReadAll(resp.Body)
 	bodyStr := string(data)
 	debug.Log("[WL] HTTP %d  response: %s", resp.StatusCode, bodyStr)
+
+	// 5xx server errors are transient — retry later via the queue.
+	if resp.StatusCode >= 500 {
+		debug.Log("[WL] server error %d — treating as transient", resp.StatusCode)
+		return &QSOResult{Success: false, Reason: ReasonServerError}, nil
+	}
 
 	// Detect HTML response (wrong URL).
 	if strings.Contains(bodyStr, "<html") || strings.Contains(bodyStr, "<!DOCTYPE") {

--- a/internal/wavelog/client.go
+++ b/internal/wavelog/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"waveloggate/internal/adif"
@@ -61,8 +62,10 @@ type Station struct {
 }
 
 // Client communicates with the Wavelog API.
+// cfg is an atomic pointer: UpdateProfile swaps it from the UI goroutine while
+// UDP handlers and the retry-queue goroutine read it concurrently.
 type Client struct {
-	cfg        *config.Profile
+	cfg        atomic.Pointer[config.Profile]
 	httpClient *http.Client
 	userAgent  string
 }
@@ -72,19 +75,20 @@ func New(cfg *config.Profile, appVersion string) *Client {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
 	}
-	return &Client{
-		cfg: cfg,
+	c := &Client{
 		httpClient: &http.Client{
 			Timeout:   5 * time.Second,
 			Transport: transport,
 		},
 		userAgent: "WavelogGate/" + appVersion,
 	}
+	c.cfg.Store(cfg)
+	return c
 }
 
 // UpdateProfile updates the config profile used by the client.
 func (c *Client) UpdateProfile(cfg *config.Profile) {
-	c.cfg = cfg
+	c.cfg.Store(cfg)
 }
 
 type qsoPayload struct {
@@ -116,7 +120,8 @@ func redactKey(key string) string {
 
 // SendQSO posts an ADIF string to Wavelog. dryRun uses /api/qso/true.
 func (c *Client) SendQSO(adifStr string, dryRun bool) (*QSOResult, error) {
-	endpoint := strings.TrimRight(c.cfg.WavelogURL, "/") + "/api/qso"
+	cfg := c.cfg.Load()
+	endpoint := strings.TrimRight(cfg.WavelogURL, "/") + "/api/qso"
 	if dryRun {
 		endpoint += "/true"
 	}
@@ -126,8 +131,8 @@ func (c *Client) SendQSO(adifStr string, dryRun bool) (*QSOResult, error) {
 	qsoInfo := adif.Parse(adifStr)
 
 	payload := qsoPayload{
-		Key:              c.cfg.WavelogKey,
-		StationProfileID: c.cfg.WavelogID,
+		Key:              cfg.WavelogKey,
+		StationProfileID: cfg.WavelogID,
 		Type:             "adif",
 		String:           adifStr,
 	}
@@ -135,7 +140,7 @@ func (c *Client) SendQSO(adifStr string, dryRun bool) (*QSOResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	debug.Log("[WL] payload: %s", strings.Replace(string(body), c.cfg.WavelogKey, redactKey(c.cfg.WavelogKey), -1))
+	debug.Log("[WL] payload: %s", strings.Replace(string(body), cfg.WavelogKey, redactKey(cfg.WavelogKey), -1))
 
 	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(body))
 	if err != nil {
@@ -214,7 +219,8 @@ type radioPayload struct {
 
 // UpdateRadioStatus posts radio status to Wavelog's /api/radio.
 func (c *Client) UpdateRadioStatus(data RadioData) error {
-	endpoint := strings.TrimRight(c.cfg.WavelogURL, "/") + "/api/radio"
+	cfg := c.cfg.Load()
+	endpoint := strings.TrimRight(cfg.WavelogURL, "/") + "/api/radio"
 
 	freq := data.Frequency
 	freqRx := data.FrequencyRx
@@ -228,8 +234,8 @@ func (c *Client) UpdateRadioStatus(data RadioData) error {
 	}
 
 	p := radioPayload{
-		Radio:       c.cfg.WavelogRadioname,
-		Key:         c.cfg.WavelogKey,
+		Radio:       cfg.WavelogRadioname,
+		Key:         cfg.WavelogKey,
 		Frequency:   freq,
 		Mode:        mode,
 		FrequencyRx: freqRx,
@@ -265,7 +271,8 @@ func (c *Client) UpdateRadioStatus(data RadioData) error {
 
 // GetStations fetches the station profile list from Wavelog.
 func (c *Client) GetStations() ([]Station, error) {
-	endpoint := strings.TrimRight(c.cfg.WavelogURL, "/") + "/api/station_info/" + c.cfg.WavelogKey
+	cfg := c.cfg.Load()
+	endpoint := strings.TrimRight(cfg.WavelogURL, "/") + "/api/station_info/" + cfg.WavelogKey
 
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {


### PR DESCRIPTION
Adding QSO Buffering (when connection lost) to WavelogGate.
Behaviour:
 - When there's no internet, the QSOs sent to the Gate via UDP/2333 are buffered.
 - There's a retrylogic, once connection is back. Furthermore User can empty the queue or trigger retry on his own.
 - buffering survives a restart of WavelogGate