### PR TITLE
run the aur task only in original repo

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -287,7 +287,7 @@ jobs:
   aur:
     needs: release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'wavelog/WaveLogGate'
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
reduce noise during testing releases