### PR TITLE
Fix mode flapping

### DIFF
--- a/internal/radio/client.go
+++ b/internal/radio/client.go
@@ -262,11 +262,14 @@ func (c *HamlibClient) sendCmd(cmd string) (string, error) {
 	}
 
 	reader := bufio.NewReader(conn)
-	line, _ := reader.ReadString('\n')
+	line, readErr := reader.ReadString('\n')
 	line = strings.TrimSpace(line)
 
 	if strings.HasPrefix(line, "RPRT") {
 		return "", fmt.Errorf("hamlib error: %s", line)
+	}
+	if readErr != nil && line == "" {
+		return "", fmt.Errorf("hamlib read error for cmd %q: %w", strings.TrimSpace(cmd), readErr)
 	}
 	return line, nil
 }

--- a/internal/radio/client.go
+++ b/internal/radio/client.go
@@ -269,7 +269,7 @@ func (c *HamlibClient) sendCmd(cmd string) (string, error) {
 		return "", fmt.Errorf("hamlib error: %s", line)
 	}
 	if readErr != nil && line == "" {
-		return "", fmt.Errorf("hamlib read error for cmd %q: %w", strings.TrimSpace(cmd), readErr)
+		return "", readErr
 	}
 	return line, nil
 }

--- a/internal/radio/client.go
+++ b/internal/radio/client.go
@@ -369,7 +369,10 @@ func (c *HamlibClient) GetStatus() (RigStatus, error) {
 	}
 	s.FreqA, _ = strconv.ParseFloat(freqStr, 64)
 
-	modeStr, _ := c.sendCmd("m\n")
+	modeStr, err := c.sendCmd("m\n")
+	if err != nil {
+		return s, err
+	}
 	s.Mode = strings.TrimSpace(modeStr)
 
 	// IC-9700 SAT mode: Main band = downlink (RX), Sub band = uplink (TX).


### PR DESCRIPTION
On hamlib it can happen that hamlib itself resets the connection from time to time. In this moment frequency error is handled but not mode error. So the mode flapps between `""` and `"[mode]"` which is a bit annoying and causes issues in event based handles (wavelog worker work in progress)